### PR TITLE
Refactor using the DisplayConfig api

### DIFF
--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.cpp
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.cpp
@@ -148,25 +148,26 @@ bool FOSVRHMD::OnStartGameFrame(FWorldContext& WorldContext) {
 
 float FOSVRHMD::GetInterpupillaryDistance() const
 {
-    if (osvrClientCheckDisplayStartup(DisplayConfig) == OSVR_RETURN_SUCCESS) {
-        OSVR_Pose3 leftEye, rightEye;
-        OSVR_ReturnCode returnCode;
+    return HMDDescription.GetInterpupillaryDistance();
+    //if (osvrClientCheckDisplayStartup(DisplayConfig) == OSVR_RETURN_SUCCESS) {
+    //    OSVR_Pose3 leftEye, rightEye;
+    //    OSVR_ReturnCode returnCode;
 
-        returnCode = osvrClientGetViewerEyePose(DisplayConfig, 0, 0, &leftEye);
-        check(returnCode == OSVR_RETURN_SUCCESS);
+    //    returnCode = osvrClientGetViewerEyePose(DisplayConfig, 0, 0, &leftEye);
+    //    check(returnCode == OSVR_RETURN_SUCCESS);
 
-        returnCode = osvrClientGetViewerEyePose(DisplayConfig, 0, 0, &rightEye);
-        check(returnCode == OSVR_RETURN_SUCCESS);
+    //    returnCode = osvrClientGetViewerEyePose(DisplayConfig, 0, 1, &rightEye);
+    //    check(returnCode == OSVR_RETURN_SUCCESS);
 
-        double dx = leftEye.translation.data[0] - rightEye.translation.data[0];
-        double dy = leftEye.translation.data[1] - rightEye.translation.data[1];
-        double dz = leftEye.translation.data[2] - rightEye.translation.data[2];
+    //    double dx = leftEye.translation.data[0] - rightEye.translation.data[0];
+    //    double dy = leftEye.translation.data[1] - rightEye.translation.data[1];
+    //    double dz = leftEye.translation.data[2] - rightEye.translation.data[2];
 
-        double ret = std::sqrt(dx * dx + dy * dy + dz * dz);
-        return (float)ret;
-    }
-    // return the mean IPD
-    return 0.065f;
+    //    double ret = std::sqrt(dx * dx + dy * dy + dz * dz);
+    //    return (float)ret;
+    //}
+    //// return the mean IPD
+    //return 0.065f;
 }
 
 void FOSVRHMD::SetInterpupillaryDistance(float NewInterpupillaryDistance)
@@ -564,10 +565,10 @@ FOSVRHMD::FOSVRHMD()
     //OSVRClientInterface(nullptr),
     //OSVRInterfaceName("/me/head")
 {
-    HMDDescription.Init(osvrClientContext);
+    EnablePositionalTracking(true);
+    HMDDescription.Init(osvrClientContext, DisplayConfig);
     //OSVRInterfaceName = HMDDescription.GetPositionalTrackerInterface(OSVRHMDDescription::LEFT_EYE);
 
-    EnablePositionalTracking(true);
 
     // enable vsync
     IConsoleVariable* CVSyncVar = IConsoleManager::Get().FindConsoleVariable(TEXT("r.VSync"));

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.cpp
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.cpp
@@ -56,22 +56,21 @@ EHMDDeviceType::Type FOSVRHMD::GetHMDDeviceType() const
     return EHMDDeviceType::DT_ES2GenericStereoMesh;
 }
 
+// @todo: move this to OSVRHMDDescription
 void FOSVRHMD::GetMonitorInfo(IHeadMountedDisplay::MonitorInfo& MonitorDesc) const {
+    OSVR_ReturnCode returnCode;
+
     OSVR_DisplayDimension width, height;
-    if (osvrClientGetDisplayDimensions(DisplayConfig, 0, &width, &height) == OSVR_RETURN_FAILURE) {
-        // @todo error handling
-    }
+    returnCode = osvrClientGetDisplayDimensions(DisplayConfig, 0, &width, &height);
+    check(returnCode == OSVR_RETURN_SUCCESS);
 
     OSVR_ViewportDimension left, bottomIgnored, widthIgnored, heightIgnored;
-    if (osvrClientGetRelativeViewportForViewerEyeSurface(DisplayConfig, 0, 0, 0,
-        &left, &bottomIgnored, &widthIgnored, &heightIgnored) == OSVR_RETURN_FAILURE) {
-        // @todo error handling
-    }
+    returnCode = osvrClientGetRelativeViewportForViewerEyeSurface(DisplayConfig, 0, 0, 0,
+        &left, &bottomIgnored, &widthIgnored, &heightIgnored);
+    check(returnCode == OSVR_RETURN_SUCCESS);
 
     MonitorDesc.MonitorName = "OSVR-Display"; //@TODO
     MonitorDesc.MonitorId = 0;				  //@TODO
-    //MonitorDesc.DesktopX = GetDisplayOrigin(OSVRHMDDescription::LEFT_EYE).X;
-    //MonitorDesc.DesktopY = GetDisplayOrigin(OSVRHMDDescription::LEFT_EYE).Y;
     MonitorDesc.DesktopX = left;
     MonitorDesc.DesktopY = 0;
     MonitorDesc.ResolutionX = width;
@@ -149,25 +148,6 @@ bool FOSVRHMD::OnStartGameFrame(FWorldContext& WorldContext) {
 float FOSVRHMD::GetInterpupillaryDistance() const
 {
     return HMDDescription.GetInterpupillaryDistance();
-    //if (osvrClientCheckDisplayStartup(DisplayConfig) == OSVR_RETURN_SUCCESS) {
-    //    OSVR_Pose3 leftEye, rightEye;
-    //    OSVR_ReturnCode returnCode;
-
-    //    returnCode = osvrClientGetViewerEyePose(DisplayConfig, 0, 0, &leftEye);
-    //    check(returnCode == OSVR_RETURN_SUCCESS);
-
-    //    returnCode = osvrClientGetViewerEyePose(DisplayConfig, 0, 1, &rightEye);
-    //    check(returnCode == OSVR_RETURN_SUCCESS);
-
-    //    double dx = leftEye.translation.data[0] - rightEye.translation.data[0];
-    //    double dy = leftEye.translation.data[1] - rightEye.translation.data[1];
-    //    double dz = leftEye.translation.data[2] - rightEye.translation.data[2];
-
-    //    double ret = std::sqrt(dx * dx + dy * dy + dz * dz);
-    //    return (float)ret;
-    //}
-    //// return the mean IPD
-    //return 0.065f;
 }
 
 void FOSVRHMD::SetInterpupillaryDistance(float NewInterpupillaryDistance)
@@ -312,7 +292,6 @@ bool FOSVRHMD::EnablePositionalTracking(bool enable)
 {
     if (enable && !IsPositionalTrackingEnabled())
     {
-        //OSVR_ReturnCode ReturnCode = osvrClientGetInterface(osvrClientContext, TCHAR_TO_ANSI(*OSVRInterfaceName), &OSVRClientInterface);
         OSVR_ReturnCode ReturnCode = osvrClientGetDisplay(osvrClientContext, &DisplayConfig);
         if (ReturnCode == OSVR_RETURN_SUCCESS)
         {
@@ -321,8 +300,6 @@ bool FOSVRHMD::EnablePositionalTracking(bool enable)
                 osvrClientUpdate(osvrClientContext);
             }
             if (osvrClientCheckDisplayStartup(DisplayConfig) == OSVR_RETURN_SUCCESS) {
-                //ReturnCode = osvrRegisterPoseCallback(osvrClientContext, &OSVRPoseCallback, this);
-                //bHmdPosTracking = ReturnCode == OSVR_RETURN_SUCCESS;
                 bHmdPosTracking = true;
             }
         }
@@ -331,13 +308,8 @@ bool FOSVRHMD::EnablePositionalTracking(bool enable)
     {
         if (DisplayConfig != nullptr)
         {
-            //OSVR_ReturnCode ReturnCode = osvrClientFreeInterface(osvrClientContext, OSVRClientInterface);
             OSVR_ReturnCode ReturnCode = osvrClientFreeDisplay(DisplayConfig);
             check(ReturnCode == OSVR_RETURN_SUCCESS);
-
-            //@TODO: unregister pose callback but this call is missing in the OSVR API !
-
-            //OSVRClientInterface = nullptr;
             DisplayConfig = nullptr;
         }
 
@@ -400,9 +372,7 @@ void FOSVRHMD::ResetOrientation(bool adjustOrientation, float yaw)
 {
     FQuat CurrentRotation(FQuat::Identity);
 
-    //OSVR_TimeValue Time;
     OSVR_PoseState Pose;
-    //OSVR_ReturnCode ReturnCode = osvrGetPoseState(OSVRClientInterface, &Time, &Pose);
     OSVR_ReturnCode ReturnCode = osvrClientGetViewerPose(DisplayConfig, 0, &Pose);
     if (ReturnCode != OSVR_RETURN_SUCCESS)
         return;
@@ -434,9 +404,7 @@ void FOSVRHMD::ResetOrientation(bool adjustOrientation, float yaw)
 void FOSVRHMD::ResetPosition()
 {
     FVector CurrentPosition(FVector::ZeroVector);
-    //OSVR_TimeValue Time;
     OSVR_PoseState Pose;
-    //OSVR_ReturnCode ReturnCode = osvrGetPoseState(OSVRClientInterface, &Time, &Pose);
     OSVR_ReturnCode ReturnCode = osvrClientGetViewerPose(DisplayConfig, 0, &Pose);
     if (ReturnCode != OSVR_RETURN_SUCCESS)
         return;
@@ -462,6 +430,7 @@ FMatrix FOSVRHMD::GetStereoProjectionMatrix(enum EStereoscopicPass StereoPassTyp
     FMatrix original = HMDDescription.GetProjectionMatrix(
         StereoPassType == eSSP_LEFT_EYE ? OSVRHMDDescription::LEFT_EYE : OSVRHMDDescription::RIGHT_EYE);
 
+    // @todo we should be getting a matrix from core, but this doesn't appear to be working.
     //OSVR_EyeCount eye = 0;
     //if (StereoPassType == eSSP_LEFT_EYE) {
     //    eye = 0;
@@ -481,14 +450,10 @@ FMatrix FOSVRHMD::GetStereoProjectionMatrix(enum EStereoscopicPass StereoPassTyp
     //    FPlane(0, 1, 0, 0),
     //    FPlane(0, 0, 0, 1));
 
-    //// @todo do a change of basis here
+    //// @todo do a change of basis here? Seems to make it worse??
     //FMatrix preMultiply = axisChange * ret;
     //FMatrix postMultiply = ret * axisChange;
     return original;
-    // @todo: do we need to do an axis change here? if so, is it pre or post-multiplied?
-    //return ret;
-    //return preMultiply;
-    //return postMultiply;
 }
 
 void FOSVRHMD::InitCanvasFromView(FSceneView* InView, UCanvas* Canvas)
@@ -535,18 +500,6 @@ bool FOSVRHMD::IsHeadTrackingAllowed() const
     return GEngine->IsStereoscopic3D();
 }
 
-//static void OSVRPoseCallback(void* Userdata, const OSVR_TimeValue* /*Timestamp*/, const OSVR_PoseReport* Report)
-//{
-//  auto This = reinterpret_cast< FOSVRHMD* >(Userdata);
-//  if (This && Report)
-//  {
-//    This->CurHmdPosition = This->BaseOrientation.Inverse().RotateVector((OSVR2FVector(Report->pose.translation) * This->WorldToMetersScale) - This->BasePosition);
-//    This->CurHmdOrientation = This->BaseOrientation.Inverse() * OSVR2FQuat(Report->pose.rotation);
-//
-//    This->bHaveVisionTracking = true;
-//  }
-//}
-
 FOSVRHMD::FOSVRHMD()
     : LastHmdOrientation(FQuat::Identity),
     CurHmdOrientation(FQuat::Identity),
@@ -562,13 +515,9 @@ FOSVRHMD::FOSVRHMD()
     bHmdEnabled(true),
     bHmdOverridesApplied(false),
     DisplayConfig(nullptr)
-    //OSVRClientInterface(nullptr),
-    //OSVRInterfaceName("/me/head")
 {
     EnablePositionalTracking(true);
     HMDDescription.Init(osvrClientContext, DisplayConfig);
-    //OSVRInterfaceName = HMDDescription.GetPositionalTrackerInterface(OSVRHMDDescription::LEFT_EYE);
-
 
     // enable vsync
     IConsoleVariable* CVSyncVar = IConsoleManager::Get().FindConsoleVariable(TEXT("r.VSync"));

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.h
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.h
@@ -154,12 +154,7 @@ private:
   bool bStereoEnabled;
   bool bHmdEnabled;
   bool bHmdOverridesApplied;
-  //friend static void OSVRPoseCallback(void* Userdata, const OSVR_TimeValue* /*Timestamp*/, const OSVR_PoseReport* Report);
 
   OSVRHMDDescription HMDDescription;
   OSVR_DisplayConfig DisplayConfig;
-
-  //OSVR_ClientInterface OSVRClientInterface;
-
-  //FString OSVRInterfaceName;
 };

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.h
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.h
@@ -24,136 +24,141 @@
 #include "SceneView.h"
 #include "ShowFlags.h"
 
+#include <osvr/ClientKit/DisplayC.h>
+
 /**
  * OSVR Head Mounted Display
  */
 class FOSVRHMD : public IHeadMountedDisplay, public ISceneViewExtension, public TSharedFromThis< FOSVRHMD, ESPMode::ThreadSafe >
 {
 public:
-	/** IHeadMountedDisplay interface */
-	virtual bool IsHMDConnected() override;
-	virtual bool IsHMDEnabled() const override;
-	virtual void EnableHMD(bool allow = true) override;
-	virtual EHMDDeviceType::Type GetHMDDeviceType() const override;
-	virtual bool GetHMDMonitorInfo(MonitorInfo&) override;
+  /** IHeadMountedDisplay interface */
+  virtual bool IsHMDConnected() override;
+  virtual bool IsHMDEnabled() const override;
+  virtual void EnableHMD(bool allow = true) override;
+  virtual EHMDDeviceType::Type GetHMDDeviceType() const override;
+  virtual bool GetHMDMonitorInfo(MonitorInfo&) override;
 
-	virtual void GetFieldOfView(float& OutHFOVInDegrees, float& OutVFOVInDegrees) const override;
+  virtual void GetFieldOfView(float& OutHFOVInDegrees, float& OutVFOVInDegrees) const override;
 
-	virtual bool DoesSupportPositionalTracking() const override;
-	virtual bool HasValidTrackingPosition() override;
-	virtual void GetPositionalTrackingCameraProperties(FVector& OutOrigin, FQuat& OutOrientation, float& OutHFOV, float& OutVFOV, float& OutCameraDistance, float& OutNearPlane, float& OutFarPlane) const override;
+  virtual bool DoesSupportPositionalTracking() const override;
+  virtual bool HasValidTrackingPosition() override;
+  virtual void GetPositionalTrackingCameraProperties(FVector& OutOrigin, FQuat& OutOrientation, float& OutHFOV, float& OutVFOV, float& OutCameraDistance, float& OutNearPlane, float& OutFarPlane) const override;
 
-	virtual void SetInterpupillaryDistance(float NewInterpupillaryDistance) override;
-	virtual float GetInterpupillaryDistance() const override;
+  virtual void SetInterpupillaryDistance(float NewInterpupillaryDistance) override;
+  virtual float GetInterpupillaryDistance() const override;
 
-	virtual void GetCurrentOrientationAndPosition(FQuat& CurrentOrientation, FVector& CurrentPosition) override;
-	virtual TSharedPtr< class ISceneViewExtension, ESPMode::ThreadSafe > GetViewExtension() override;
-	virtual void ApplyHmdRotation(APlayerController* PC, FRotator& ViewRotation) override;
-	virtual void UpdatePlayerCameraRotation(class APlayerCameraManager* Camera, struct FMinimalViewInfo& POV) override;
+  virtual void GetCurrentOrientationAndPosition(FQuat& CurrentOrientation, FVector& CurrentPosition) override;
+  virtual TSharedPtr< class ISceneViewExtension, ESPMode::ThreadSafe > GetViewExtension() override;
+  virtual void ApplyHmdRotation(APlayerController* PC, FRotator& ViewRotation) override;
+  virtual void UpdatePlayerCameraRotation(class APlayerCameraManager* Camera, struct FMinimalViewInfo& POV) override;
 
-	virtual bool IsChromaAbCorrectionEnabled() const override;
+  virtual bool IsChromaAbCorrectionEnabled() const override;
 
-	virtual bool Exec(UWorld* InWorld, const TCHAR* Cmd, FOutputDevice& Ar) override;
-	virtual void OnScreenModeChange(EWindowMode::Type WindowMode) override;
+  virtual bool Exec(UWorld* InWorld, const TCHAR* Cmd, FOutputDevice& Ar) override;
+  virtual void OnScreenModeChange(EWindowMode::Type WindowMode) override;
 
-	virtual bool IsPositionalTrackingEnabled() const override;
-	virtual bool EnablePositionalTracking(bool enable) override;
+  virtual bool IsPositionalTrackingEnabled() const override;
+  virtual bool EnablePositionalTracking(bool enable) override;
 
-	virtual bool IsHeadTrackingAllowed() const override;
+  virtual bool IsHeadTrackingAllowed() const override;
 
-	virtual bool IsInLowPersistenceMode() const override;
-	virtual void EnableLowPersistenceMode(bool Enable = true) override;
-    virtual bool OnStartGameFrame(FWorldContext& WorldContext) override;
+  virtual bool IsInLowPersistenceMode() const override;
+  virtual void EnableLowPersistenceMode(bool Enable = true) override;
+  virtual bool OnStartGameFrame(FWorldContext& WorldContext) override;
 
 #if 0
-    // seen in simplehmd
-	virtual void SetClippingPlanes(float NCP, float FCP) override;
+  // seen in simplehmd
+  virtual void SetClippingPlanes(float NCP, float FCP) override;
 
-	virtual void SetBaseRotation(const FRotator& BaseRot) override;
-	virtual FRotator GetBaseRotation() const override;
+  virtual void SetBaseRotation(const FRotator& BaseRot) override;
+  virtual FRotator GetBaseRotation() const override;
 
-	virtual void SetBaseOrientation(const FQuat& BaseOrient) override;
-	virtual FQuat GetBaseOrientation() const override;
+  virtual void SetBaseOrientation(const FQuat& BaseOrient) override;
+  virtual FQuat GetBaseOrientation() const override;
 #endif
 
-	virtual void DrawDistortionMesh_RenderThread(struct FRenderingCompositePassContext& Context, const FIntPoint& TextureSize) override;
+  virtual void DrawDistortionMesh_RenderThread(struct FRenderingCompositePassContext& Context, const FIntPoint& TextureSize) override;
 
-	/** IStereoRendering interface */
-	virtual bool IsStereoEnabled() const override;
-	virtual bool EnableStereo(bool stereo = true) override;
-	virtual void AdjustViewRect(EStereoscopicPass StereoPass, int32& X, int32& Y, uint32& SizeX, uint32& SizeY) const override;
-	virtual void CalculateStereoViewOffset(const EStereoscopicPass StereoPassType, const FRotator& ViewRotation,
-										   const float MetersToWorld, FVector& ViewLocation) override;
-	virtual FMatrix GetStereoProjectionMatrix(const EStereoscopicPass StereoPassType, const float FOV) const override;
-	virtual void InitCanvasFromView(FSceneView* InView, UCanvas* Canvas) override;
-	virtual void GetEyeRenderParams_RenderThread(const struct FRenderingCompositePassContext& Context, FVector2D& EyeToSrcUVScaleValue, FVector2D& EyeToSrcUVOffsetValue) const override;
-	virtual void GetTimewarpMatrices_RenderThread(const struct FRenderingCompositePassContext& Context, FMatrix& EyeRotationStart, FMatrix& EyeRotationEnd) const override;
+  /** IStereoRendering interface */
+  virtual bool IsStereoEnabled() const override;
+  virtual bool EnableStereo(bool stereo = true) override;
+  virtual void AdjustViewRect(EStereoscopicPass StereoPass, int32& X, int32& Y, uint32& SizeX, uint32& SizeY) const override;
+  virtual void CalculateStereoViewOffset(const EStereoscopicPass StereoPassType, const FRotator& ViewRotation,
+  const float MetersToWorld, FVector& ViewLocation) override;
+  virtual FMatrix GetStereoProjectionMatrix(const EStereoscopicPass StereoPassType, const float FOV) const override;
+  virtual void InitCanvasFromView(FSceneView* InView, UCanvas* Canvas) override;
+  virtual void GetEyeRenderParams_RenderThread(const struct FRenderingCompositePassContext& Context, FVector2D& EyeToSrcUVScaleValue, FVector2D& EyeToSrcUVOffsetValue) const override;
+  virtual void GetTimewarpMatrices_RenderThread(const struct FRenderingCompositePassContext& Context, FMatrix& EyeRotationStart, FMatrix& EyeRotationEnd) const override;
 
-	virtual void UpdateViewport(bool bUseSeparateRenderTarget, const FViewport& Viewport, class SViewport*) override;
+  virtual void UpdateViewport(bool bUseSeparateRenderTarget, const FViewport& Viewport, class SViewport*) override;
 
-	virtual bool ShouldUseSeparateRenderTarget() const override
-	{
-		return false;
-	}
+  virtual bool ShouldUseSeparateRenderTarget() const override
+  {
+    return false;
+  }
 
-	/** ISceneViewExtension interface */
-	virtual void SetupViewFamily(FSceneViewFamily& InViewFamily) override;
-	virtual void SetupView(FSceneViewFamily& InViewFamily, FSceneView& InView) override;
-	virtual void BeginRenderViewFamily(FSceneViewFamily& InViewFamily)
-	{
-	}
-	virtual void PreRenderView_RenderThread(FRHICommandListImmediate& RHICmdList, FSceneView& InView) override;
-	virtual void PreRenderViewFamily_RenderThread(FRHICommandListImmediate& RHICmdList, FSceneViewFamily& InViewFamily) override;
+  /** ISceneViewExtension interface */
+  virtual void SetupViewFamily(FSceneViewFamily& InViewFamily) override;
+  virtual void SetupView(FSceneViewFamily& InViewFamily, FSceneView& InView) override;
+  virtual void BeginRenderViewFamily(FSceneViewFamily& InViewFamily)
+  {
+  }
+  virtual void PreRenderView_RenderThread(FRHICommandListImmediate& RHICmdList, FSceneView& InView) override;
+  virtual void PreRenderViewFamily_RenderThread(FRHICommandListImmediate& RHICmdList, FSceneViewFamily& InViewFamily) override;
 
-	/** Resets orientation by setting roll and pitch to 0, 
-	    assuming that current yaw is forward direction and assuming
-		current position as 0 point. */
-	virtual void ResetOrientation(float yaw) override;
-	void ResetOrientation(bool adjustOrientation, float yaw);
-	virtual void ResetPosition() override;
-	virtual void ResetOrientationAndPosition(float yaw = 0.f) override;
-	void SetCurrentHmdOrientationAndPositionAsBase();
+  /** Resets orientation by setting roll and pitch to 0,
+      assuming that current yaw is forward direction and assuming
+      current position as 0 point. */
+  virtual void ResetOrientation(float yaw) override;
+  void ResetOrientation(bool adjustOrientation, float yaw);
+  virtual void ResetPosition() override;
+  virtual void ResetOrientationAndPosition(float yaw = 0.f) override;
+  void SetCurrentHmdOrientationAndPositionAsBase();
 
 public:
-	/** Constructor */
-	FOSVRHMD();
+  /** Constructor */
+  FOSVRHMD();
 
-	/** Destructor */
-	virtual ~FOSVRHMD();
+  /** Destructor */
+  virtual ~FOSVRHMD();
 
-	/** @return	True if the HMD was initialized OK */
-	bool IsInitialized() const;
+  /** @return	True if the HMD was initialized OK */
+  bool IsInitialized() const;
 
 private:
-	/** Player's orientation tracking */
-	mutable FQuat CurHmdOrientation;
+  void GetMonitorInfo(IHeadMountedDisplay::MonitorInfo& MonitorDesc) const;
 
-	FRotator DeltaControlRotation; // same as DeltaControlOrientation but as rotator
-	FQuat DeltaControlOrientation; // same as DeltaControlRotation but as quat
+  /** Player's orientation tracking */
+  mutable FQuat CurHmdOrientation;
 
-	mutable FVector CurHmdPosition;
+  FRotator DeltaControlRotation; // same as DeltaControlOrientation but as rotator
+  FQuat DeltaControlOrientation; // same as DeltaControlRotation but as quat
 
-	mutable FQuat LastHmdOrientation; // contains last APPLIED ON GT HMD orientation
-	FVector LastHmdPosition;		  // contains last APPLIED ON GT HMD position
+  mutable FVector CurHmdPosition;
 
-	/** HMD base values, specify forward orientation and zero pos offset */
-	FQuat BaseOrientation; // base orientation
-	FVector BasePosition;
+  mutable FQuat LastHmdOrientation; // contains last APPLIED ON GT HMD orientation
+  FVector LastHmdPosition;		  // contains last APPLIED ON GT HMD position
 
-	/** World units (UU) to Meters scale.  Read from the level, and used to transform positional tracking data */
-	float WorldToMetersScale;
+  /** HMD base values, specify forward orientation and zero pos offset */
+  FQuat BaseOrientation; // base orientation
+  FVector BasePosition;
 
-	bool bHmdPosTracking;
-	bool bHaveVisionTracking;
+  /** World units (UU) to Meters scale.  Read from the level, and used to transform positional tracking data */
+  float WorldToMetersScale;
 
-	bool bStereoEnabled;
-	bool bHmdEnabled;
-    bool bHmdOverridesApplied;
-	friend static void OSVRPoseCallback(void* Userdata, const OSVR_TimeValue* /*Timestamp*/, const OSVR_PoseReport* Report);
+  bool bHmdPosTracking;
+  bool bHaveVisionTracking;
 
-	OSVRHMDDescription HMDDescription;
+  bool bStereoEnabled;
+  bool bHmdEnabled;
+  bool bHmdOverridesApplied;
+  //friend static void OSVRPoseCallback(void* Userdata, const OSVR_TimeValue* /*Timestamp*/, const OSVR_PoseReport* Report);
 
-	OSVR_ClientInterface OSVRClientInterface;
+  OSVRHMDDescription HMDDescription;
+  OSVR_DisplayConfig DisplayConfig;
 
-	FString OSVRInterfaceName;
+  //OSVR_ClientInterface OSVRClientInterface;
+
+  //FString OSVRInterfaceName;
 };

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.h
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.h
@@ -128,6 +128,7 @@ public:
 
 private:
   void GetMonitorInfo(IHeadMountedDisplay::MonitorInfo& MonitorDesc) const;
+  void UpdateHeadPose();
 
   /** Player's orientation tracking */
   mutable FQuat CurHmdOrientation;

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMDDescription.cpp
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMDDescription.cpp
@@ -19,6 +19,8 @@
 
 #include "Json.h"
 
+#include <cmath>
+
 struct DescriptionData
 {
 	FVector2D DisplaySize[2];
@@ -145,8 +147,8 @@ void OSVRHMDDescription::InitFOV(OSVR_DisplayConfig displayConfig) {
         returnCode = osvrClientGetViewerEyeSurfaceProjectionClippingPlanes(displayConfig, 0, 0, eye, &left, &right, &bottom, &top);
         check(returnCode == OSVR_RETURN_SUCCESS);
 
-        double horizontalFOV = FMath::RadiansToDegrees(atan(std::abs(left)) + atan(std::abs(right)));
-        double verticalFOV = FMath::RadiansToDegrees(atan(std::abs(top)) + atan(std::abs(bottom)));
+        double horizontalFOV = FMath::RadiansToDegrees(std::atan(std::abs(left)) + std::atan(std::abs(right)));
+        double verticalFOV = FMath::RadiansToDegrees(std::atan(std::abs(top)) + std::atan(std::abs(bottom)));
         auto data = GetData(Data);
         data.Fov[eye] = FVector2D(horizontalFOV, verticalFOV);
     }

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMDDescription.cpp
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMDDescription.cpp
@@ -21,11 +21,11 @@
 
 struct DescriptionData
 {
-	//FVector2D DisplaySize[2];
-	//FVector2D DisplayOrigin[2];
+	FVector2D DisplaySize[2];
+	FVector2D DisplayOrigin[2];
 	FVector2D Fov[2];
-	//FVector Location[2];
-	//FString PositionalTrackerInterface[2];
+	FVector Location[2];
+	FString PositionalTrackerInterface[2];
 
 	DescriptionData();
 
@@ -42,11 +42,11 @@ DescriptionData::DescriptionData()
 	// Set defaults...
 	for (int i = 0; i < 2; ++i)
 	{
-		//DisplaySize[i].Set(960, 1080);
-		//DisplayOrigin[i].Set(i == 0 ? 0 : 960, 0);
+		DisplaySize[i].Set(960, 1080);
+		DisplayOrigin[i].Set(i == 0 ? 0 : 960, 0);
 		Fov[i].Set(90, 101.25f);
-		//Location[i].Set(i == 0 ? -0.0325 : 0.0325, 0, 0);
-		//PositionalTrackerInterface[i] = "/me/head";
+		Location[i].Set(i == 0 ? -0.0325 : 0.0325, 0, 0);
+		PositionalTrackerInterface[i] = "/me/head";
 	}
 }
 
@@ -59,20 +59,20 @@ bool DescriptionData::InitFromJSON(const char* JSON)
 		JsonObject.IsValid())
 	{
 		auto hmdJson = JsonObject->GetObjectField("hmd");
-		//auto resolutionsJson = hmdJson->GetArrayField("resolutions");
+		auto resolutionsJson = hmdJson->GetArrayField("resolutions");
 		auto fieldOfViewJson = hmdJson->GetObjectField("field_of_view");
 		for (int i = 0; i < 2; ++i)
 		{
 			//set resolution
-			//DisplaySize[i].X = resolutionsJson[0]->AsObject()->GetNumberField("width") * 0.5f;
-			//DisplaySize[i].Y = resolutionsJson[0]->AsObject()->GetNumberField("height");
-			//DisplayOrigin[i].Set(i == 0 ? 0 : DisplaySize[i].X, 0);
+			DisplaySize[i].X = resolutionsJson[0]->AsObject()->GetNumberField("width") * 0.5f;
+			DisplaySize[i].Y = resolutionsJson[0]->AsObject()->GetNumberField("height");
+			DisplayOrigin[i].Set(i == 0 ? 0 : DisplaySize[i].X, 0);
 			//set field of view
 			Fov[i].X = fieldOfViewJson->GetNumberField("monocular_horizontal");
 			Fov[i].Y = fieldOfViewJson->GetNumberField("monocular_vertical");
 			//set default IPD for now. It's not coming from /display.
-			//Location[i].Set(i == 0 ? -0.0325 : 0.0325, 0, 0);
-			//PositionalTrackerInterface[i] = "/me/head";
+			Location[i].Set(i == 0 ? -0.0325 : 0.0325, 0, 0);
+			PositionalTrackerInterface[i] = "/me/head";
 		}
 	}
 	return true;
@@ -111,87 +111,90 @@ bool OSVRHMDDescription::Init(OSVR_ClientContext OSVRClientContext)
 	return Valid;
 }
 
-//FVector2D OSVRHMDDescription::GetDisplaySize(EEye Eye) const
-//{
-//	return GetData(Data).DisplaySize[Eye];
-//}
-//
-//FVector2D OSVRHMDDescription::GetDisplayOrigin(EEye Eye) const
-//{
-//	return GetData(Data).DisplayOrigin[Eye];
-//}
+FVector2D OSVRHMDDescription::GetDisplaySize(EEye Eye) const
+{
+	return GetData(Data).DisplaySize[Eye];
+}
+
+FVector2D OSVRHMDDescription::GetDisplayOrigin(EEye Eye) const
+{
+	return GetData(Data).DisplayOrigin[Eye];
+}
 
 FVector2D OSVRHMDDescription::GetFov(OSVR_EyeCount Eye) const
 {
 	return GetData(Data).Fov[Eye];
 }
+FVector2D OSVRHMDDescription::GetFov(EEye Eye) const
+{
+    return GetData(Data).Fov[Eye];
+}
+FVector OSVRHMDDescription::GetLocation(EEye Eye) const
+{
+	return GetData(Data).Location[Eye];
+}
 
-//FVector OSVRHMDDescription::GetLocation(EEye Eye) const
-//{
-//	return GetData(Data).Location[Eye];
-//}
-//
-//FString OSVRHMDDescription::GetPositionalTrackerInterface(EEye Eye) const
-//{
-//	return GetData(Data).PositionalTrackerInterface[Eye];
-//}
+FString OSVRHMDDescription::GetPositionalTrackerInterface(EEye Eye) const
+{
+	return GetData(Data).PositionalTrackerInterface[Eye];
+}
 
-//FMatrix OSVRHMDDescription::GetProjectionMatrix(EEye Eye) const
-//{
-//	// @TODO: a proper stereo projection matrix should be calculated
-//
-//	const float ProjectionCenterOffset = 0.151976421f;
-//	const float PassProjectionOffset = (Eye == LEFT_EYE) ? ProjectionCenterOffset : -ProjectionCenterOffset;
-//
-//#if 1
-//	const float HalfFov = FMath::DegreesToRadians(GetFov(Eye).X) / 2.f;
-//	const float InWidth = GetDisplaySize(Eye).X;
-//	const float InHeight = GetDisplaySize(Eye).Y;
-//	const float XS = 1.0f / tan(HalfFov);
-//	const float YS = InWidth / tan(HalfFov) / InHeight;
-//#else
-//	const float HalfFov = 2.19686294f / 2.f;
-//	const float InWidth = 640.f;
-//	const float InHeight = 480.f;
-//	const float XS = 1.0f / tan(HalfFov);
-//	const float YS = InWidth / tan(HalfFov) / InHeight;
-//#endif
-//
-//	const float InNearZ = GNearClippingPlane;
-//	return FMatrix(
-//			   FPlane(XS, 0.0f, 0.0f, 0.0f),
-//			   FPlane(0.0f, YS, 0.0f, 0.0f),
-//			   FPlane(0.0f, 0.0f, 0.0f, 1.0f),
-//			   FPlane(0.0f, 0.0f, InNearZ, 0.0f))
-//
-//		   *
-//		   FTranslationMatrix(FVector(PassProjectionOffset, 0, 0));
-//}
+FMatrix OSVRHMDDescription::GetProjectionMatrix(EEye Eye) const
+{
+	// @TODO: a proper stereo projection matrix should be calculated
 
-//void OSVRHMDDescription::GetMonitorInfo(IHeadMountedDisplay::MonitorInfo& MonitorDesc) const
-//{
-//	MonitorDesc.MonitorName = "OSVR-Display"; //@TODO
-//	MonitorDesc.MonitorId = 0;				  //@TODO
-//	MonitorDesc.DesktopX = GetDisplayOrigin(OSVRHMDDescription::LEFT_EYE).X;
-//	MonitorDesc.DesktopY = GetDisplayOrigin(OSVRHMDDescription::LEFT_EYE).Y;
-//	MonitorDesc.ResolutionX = GetResolution().X;
-//	MonitorDesc.ResolutionY = GetResolution().Y;
-//}
+	const float ProjectionCenterOffset = 0.151976421f;
+	const float PassProjectionOffset = (Eye == LEFT_EYE) ? ProjectionCenterOffset : -ProjectionCenterOffset;
 
-//float OSVRHMDDescription::GetInterpupillaryDistance() const
-//{
-//	FVector EyeDistance = GetLocation(LEFT_EYE) - GetLocation(RIGHT_EYE);
-//	return FMath::Abs(EyeDistance.X);
-//}
+#if 1
+	const float HalfFov = FMath::DegreesToRadians(GetFov(Eye).X) / 2.f;
+	const float InWidth = GetDisplaySize(Eye).X;
+	const float InHeight = GetDisplaySize(Eye).Y;
+	const float XS = 1.0f / tan(HalfFov);
+	const float YS = InWidth / tan(HalfFov) / InHeight;
+#else
+	const float HalfFov = 2.19686294f / 2.f;
+	const float InWidth = 640.f;
+	const float InHeight = 480.f;
+	const float XS = 1.0f / tan(HalfFov);
+	const float YS = InWidth / tan(HalfFov) / InHeight;
+#endif
 
-//FVector2D OSVRHMDDescription::GetResolution() const
-//{
-//	FVector2D LeftDisplay = GetDisplaySize(LEFT_EYE);
-//	FVector2D RightDisplay = GetDisplaySize(RIGHT_EYE);
-//
-//	FVector2D Resolution;
-//	Resolution.X = LeftDisplay.X + RightDisplay.X;
-//	Resolution.Y = FMath::Max(LeftDisplay.Y, RightDisplay.Y);
-//
-//	return Resolution;
-//}
+	const float InNearZ = GNearClippingPlane;
+	return FMatrix(
+			   FPlane(XS, 0.0f, 0.0f, 0.0f),
+			   FPlane(0.0f, YS, 0.0f, 0.0f),
+			   FPlane(0.0f, 0.0f, 0.0f, 1.0f),
+			   FPlane(0.0f, 0.0f, InNearZ, 0.0f))
+
+		   *
+		   FTranslationMatrix(FVector(PassProjectionOffset, 0, 0));
+}
+
+void OSVRHMDDescription::GetMonitorInfo(IHeadMountedDisplay::MonitorInfo& MonitorDesc) const
+{
+	MonitorDesc.MonitorName = "OSVR-Display"; //@TODO
+	MonitorDesc.MonitorId = 0;				  //@TODO
+	MonitorDesc.DesktopX = GetDisplayOrigin(OSVRHMDDescription::LEFT_EYE).X;
+	MonitorDesc.DesktopY = GetDisplayOrigin(OSVRHMDDescription::LEFT_EYE).Y;
+	MonitorDesc.ResolutionX = GetResolution().X;
+	MonitorDesc.ResolutionY = GetResolution().Y;
+}
+
+float OSVRHMDDescription::GetInterpupillaryDistance() const
+{
+	FVector EyeDistance = GetLocation(LEFT_EYE) - GetLocation(RIGHT_EYE);
+	return FMath::Abs(EyeDistance.X);
+}
+
+FVector2D OSVRHMDDescription::GetResolution() const
+{
+	FVector2D LeftDisplay = GetDisplaySize(LEFT_EYE);
+	FVector2D RightDisplay = GetDisplaySize(RIGHT_EYE);
+
+	FVector2D Resolution;
+	Resolution.X = LeftDisplay.X + RightDisplay.X;
+	Resolution.Y = FMath::Max(LeftDisplay.Y, RightDisplay.Y);
+
+	return Resolution;
+}

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMDDescription.cpp
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMDDescription.cpp
@@ -21,11 +21,11 @@
 
 struct DescriptionData
 {
-	FVector2D DisplaySize[2];
-	FVector2D DisplayOrigin[2];
+	//FVector2D DisplaySize[2];
+	//FVector2D DisplayOrigin[2];
 	FVector2D Fov[2];
-	FVector Location[2];
-	FString PositionalTrackerInterface[2];
+	//FVector Location[2];
+	//FString PositionalTrackerInterface[2];
 
 	DescriptionData();
 
@@ -42,11 +42,11 @@ DescriptionData::DescriptionData()
 	// Set defaults...
 	for (int i = 0; i < 2; ++i)
 	{
-		DisplaySize[i].Set(960, 1080);
-		DisplayOrigin[i].Set(i == 0 ? 0 : 960, 0);
+		//DisplaySize[i].Set(960, 1080);
+		//DisplayOrigin[i].Set(i == 0 ? 0 : 960, 0);
 		Fov[i].Set(90, 101.25f);
-		Location[i].Set(i == 0 ? -0.0325 : 0.0325, 0, 0);
-		PositionalTrackerInterface[i] = "/me/head";
+		//Location[i].Set(i == 0 ? -0.0325 : 0.0325, 0, 0);
+		//PositionalTrackerInterface[i] = "/me/head";
 	}
 }
 
@@ -59,20 +59,20 @@ bool DescriptionData::InitFromJSON(const char* JSON)
 		JsonObject.IsValid())
 	{
 		auto hmdJson = JsonObject->GetObjectField("hmd");
-		auto resolutionsJson = hmdJson->GetArrayField("resolutions");
+		//auto resolutionsJson = hmdJson->GetArrayField("resolutions");
 		auto fieldOfViewJson = hmdJson->GetObjectField("field_of_view");
 		for (int i = 0; i < 2; ++i)
 		{
 			//set resolution
-			DisplaySize[i].X = resolutionsJson[0]->AsObject()->GetNumberField("width") * 0.5f;
-			DisplaySize[i].Y = resolutionsJson[0]->AsObject()->GetNumberField("height");
-			DisplayOrigin[i].Set(i == 0 ? 0 : DisplaySize[i].X, 0);
+			//DisplaySize[i].X = resolutionsJson[0]->AsObject()->GetNumberField("width") * 0.5f;
+			//DisplaySize[i].Y = resolutionsJson[0]->AsObject()->GetNumberField("height");
+			//DisplayOrigin[i].Set(i == 0 ? 0 : DisplaySize[i].X, 0);
 			//set field of view
 			Fov[i].X = fieldOfViewJson->GetNumberField("monocular_horizontal");
 			Fov[i].Y = fieldOfViewJson->GetNumberField("monocular_vertical");
 			//set default IPD for now. It's not coming from /display.
-			Location[i].Set(i == 0 ? -0.0325 : 0.0325, 0, 0);
-			PositionalTrackerInterface[i] = "/me/head";
+			//Location[i].Set(i == 0 ? -0.0325 : 0.0325, 0, 0);
+			//PositionalTrackerInterface[i] = "/me/head";
 		}
 	}
 	return true;
@@ -111,87 +111,87 @@ bool OSVRHMDDescription::Init(OSVR_ClientContext OSVRClientContext)
 	return Valid;
 }
 
-FVector2D OSVRHMDDescription::GetDisplaySize(EEye Eye) const
-{
-	return GetData(Data).DisplaySize[Eye];
-}
+//FVector2D OSVRHMDDescription::GetDisplaySize(EEye Eye) const
+//{
+//	return GetData(Data).DisplaySize[Eye];
+//}
+//
+//FVector2D OSVRHMDDescription::GetDisplayOrigin(EEye Eye) const
+//{
+//	return GetData(Data).DisplayOrigin[Eye];
+//}
 
-FVector2D OSVRHMDDescription::GetDisplayOrigin(EEye Eye) const
-{
-	return GetData(Data).DisplayOrigin[Eye];
-}
-
-FVector2D OSVRHMDDescription::GetFov(EEye Eye) const
+FVector2D OSVRHMDDescription::GetFov(OSVR_EyeCount Eye) const
 {
 	return GetData(Data).Fov[Eye];
 }
 
-FVector OSVRHMDDescription::GetLocation(EEye Eye) const
-{
-	return GetData(Data).Location[Eye];
-}
+//FVector OSVRHMDDescription::GetLocation(EEye Eye) const
+//{
+//	return GetData(Data).Location[Eye];
+//}
+//
+//FString OSVRHMDDescription::GetPositionalTrackerInterface(EEye Eye) const
+//{
+//	return GetData(Data).PositionalTrackerInterface[Eye];
+//}
 
-FString OSVRHMDDescription::GetPositionalTrackerInterface(EEye Eye) const
-{
-	return GetData(Data).PositionalTrackerInterface[Eye];
-}
+//FMatrix OSVRHMDDescription::GetProjectionMatrix(EEye Eye) const
+//{
+//	// @TODO: a proper stereo projection matrix should be calculated
+//
+//	const float ProjectionCenterOffset = 0.151976421f;
+//	const float PassProjectionOffset = (Eye == LEFT_EYE) ? ProjectionCenterOffset : -ProjectionCenterOffset;
+//
+//#if 1
+//	const float HalfFov = FMath::DegreesToRadians(GetFov(Eye).X) / 2.f;
+//	const float InWidth = GetDisplaySize(Eye).X;
+//	const float InHeight = GetDisplaySize(Eye).Y;
+//	const float XS = 1.0f / tan(HalfFov);
+//	const float YS = InWidth / tan(HalfFov) / InHeight;
+//#else
+//	const float HalfFov = 2.19686294f / 2.f;
+//	const float InWidth = 640.f;
+//	const float InHeight = 480.f;
+//	const float XS = 1.0f / tan(HalfFov);
+//	const float YS = InWidth / tan(HalfFov) / InHeight;
+//#endif
+//
+//	const float InNearZ = GNearClippingPlane;
+//	return FMatrix(
+//			   FPlane(XS, 0.0f, 0.0f, 0.0f),
+//			   FPlane(0.0f, YS, 0.0f, 0.0f),
+//			   FPlane(0.0f, 0.0f, 0.0f, 1.0f),
+//			   FPlane(0.0f, 0.0f, InNearZ, 0.0f))
+//
+//		   *
+//		   FTranslationMatrix(FVector(PassProjectionOffset, 0, 0));
+//}
 
-FMatrix OSVRHMDDescription::GetProjectionMatrix(EEye Eye) const
-{
-	// @TODO: a proper stereo projection matrix should be calculated
+//void OSVRHMDDescription::GetMonitorInfo(IHeadMountedDisplay::MonitorInfo& MonitorDesc) const
+//{
+//	MonitorDesc.MonitorName = "OSVR-Display"; //@TODO
+//	MonitorDesc.MonitorId = 0;				  //@TODO
+//	MonitorDesc.DesktopX = GetDisplayOrigin(OSVRHMDDescription::LEFT_EYE).X;
+//	MonitorDesc.DesktopY = GetDisplayOrigin(OSVRHMDDescription::LEFT_EYE).Y;
+//	MonitorDesc.ResolutionX = GetResolution().X;
+//	MonitorDesc.ResolutionY = GetResolution().Y;
+//}
 
-	const float ProjectionCenterOffset = 0.151976421f;
-	const float PassProjectionOffset = (Eye == LEFT_EYE) ? ProjectionCenterOffset : -ProjectionCenterOffset;
+//float OSVRHMDDescription::GetInterpupillaryDistance() const
+//{
+//	FVector EyeDistance = GetLocation(LEFT_EYE) - GetLocation(RIGHT_EYE);
+//	return FMath::Abs(EyeDistance.X);
+//}
 
-#if 1
-	const float HalfFov = FMath::DegreesToRadians(GetFov(Eye).X) / 2.f;
-	const float InWidth = GetDisplaySize(Eye).X;
-	const float InHeight = GetDisplaySize(Eye).Y;
-	const float XS = 1.0f / tan(HalfFov);
-	const float YS = InWidth / tan(HalfFov) / InHeight;
-#else
-	const float HalfFov = 2.19686294f / 2.f;
-	const float InWidth = 640.f;
-	const float InHeight = 480.f;
-	const float XS = 1.0f / tan(HalfFov);
-	const float YS = InWidth / tan(HalfFov) / InHeight;
-#endif
-
-	const float InNearZ = GNearClippingPlane;
-	return FMatrix(
-			   FPlane(XS, 0.0f, 0.0f, 0.0f),
-			   FPlane(0.0f, YS, 0.0f, 0.0f),
-			   FPlane(0.0f, 0.0f, 0.0f, 1.0f),
-			   FPlane(0.0f, 0.0f, InNearZ, 0.0f))
-
-		   *
-		   FTranslationMatrix(FVector(PassProjectionOffset, 0, 0));
-}
-
-void OSVRHMDDescription::GetMonitorInfo(IHeadMountedDisplay::MonitorInfo& MonitorDesc) const
-{
-	MonitorDesc.MonitorName = "OSVR-Display"; //@TODO
-	MonitorDesc.MonitorId = 0;				  //@TODO
-	MonitorDesc.DesktopX = GetDisplayOrigin(OSVRHMDDescription::LEFT_EYE).X;
-	MonitorDesc.DesktopY = GetDisplayOrigin(OSVRHMDDescription::LEFT_EYE).Y;
-	MonitorDesc.ResolutionX = GetResolution().X;
-	MonitorDesc.ResolutionY = GetResolution().Y;
-}
-
-float OSVRHMDDescription::GetInterpupillaryDistance() const
-{
-	FVector EyeDistance = GetLocation(LEFT_EYE) - GetLocation(RIGHT_EYE);
-	return FMath::Abs(EyeDistance.X);
-}
-
-FVector2D OSVRHMDDescription::GetResolution() const
-{
-	FVector2D LeftDisplay = GetDisplaySize(LEFT_EYE);
-	FVector2D RightDisplay = GetDisplaySize(RIGHT_EYE);
-
-	FVector2D Resolution;
-	Resolution.X = LeftDisplay.X + RightDisplay.X;
-	Resolution.Y = FMath::Max(LeftDisplay.Y, RightDisplay.Y);
-
-	return Resolution;
-}
+//FVector2D OSVRHMDDescription::GetResolution() const
+//{
+//	FVector2D LeftDisplay = GetDisplaySize(LEFT_EYE);
+//	FVector2D RightDisplay = GetDisplaySize(RIGHT_EYE);
+//
+//	FVector2D Resolution;
+//	Resolution.X = LeftDisplay.X + RightDisplay.X;
+//	Resolution.Y = FMath::Max(LeftDisplay.Y, RightDisplay.Y);
+//
+//	return Resolution;
+//}

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMDDescription.h
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMDDescription.h
@@ -18,6 +18,8 @@
 
 #include "IHeadMountedDisplay.h"
 
+#include <osvr/ClientKit/DisplayC.h>
+
 class OSVRHMDDescription
 {
 public:
@@ -36,24 +38,25 @@ public:
 		RIGHT_EYE
 	};
 
-	FVector2D GetDisplaySize(EEye Eye) const;
-	FVector2D GetDisplayOrigin(EEye Eye) const;
-	FVector2D GetFov(EEye Eye) const;
-	FVector GetLocation(EEye Eye) const;
-	FString GetPositionalTrackerInterface(EEye Eye) const;
+	//FVector2D GetDisplaySize(EEye Eye) const;
+	//FVector2D GetDisplayOrigin(EEye Eye) const;
+	//FVector2D GetFov(EEye Eye) const;
+    FVector2D GetFov(OSVR_EyeCount Eye) const;
+	//FVector GetLocation(EEye Eye) const;
+	//FString GetPositionalTrackerInterface(EEye Eye) const;
 
-	FMatrix GetProjectionMatrix(EEye Eye) const;
+	//FMatrix GetProjectionMatrix(EEye Eye) const;
 
-	void GetMonitorInfo(IHeadMountedDisplay::MonitorInfo& MonitorDesc) const;
+	//void GetMonitorInfo(IHeadMountedDisplay::MonitorInfo& MonitorDesc) const;
 
 	// Helper function
 	// IPD    = ABS(GetLocation(LEFT_EYE).X - GetLocation(RIGHT_EYE).X);
-	float GetInterpupillaryDistance() const;
+	//float GetInterpupillaryDistance() const;
 
 	// Helper function
 	// Width  = GetDisplaySize(LEFT_EYE).X + GetDisplaySize(RIGHT_EYE).X;
 	// Height = MAX(GetDisplaySize(LEFT_EYE).Y, GetDisplaySize(RIGHT_EYE).Y);
-	FVector2D GetResolution() const;
+	//FVector2D GetResolution() const;
 
 private:
 	OSVRHMDDescription(OSVRHMDDescription&);

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMDDescription.h
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMDDescription.h
@@ -20,13 +20,15 @@
 
 #include <osvr/ClientKit/DisplayC.h>
 
+#include <cmath>
+
 class OSVRHMDDescription
 {
 public:
 	OSVRHMDDescription();
 	~OSVRHMDDescription();
 
-	bool Init(OSVR_ClientContext OSVRClientContext);
+	bool Init(OSVR_ClientContext OSVRClientContext, OSVR_DisplayConfig displayConfig);
 	bool IsValid() const
 	{
 		return Valid;
@@ -43,11 +45,10 @@ public:
 	FVector2D GetFov(EEye Eye) const;
     FVector2D GetFov(OSVR_EyeCount Eye) const;
 	FVector GetLocation(EEye Eye) const;
-	FString GetPositionalTrackerInterface(EEye Eye) const;
 
 	FMatrix GetProjectionMatrix(EEye Eye) const;
 
-	void GetMonitorInfo(IHeadMountedDisplay::MonitorInfo& MonitorDesc) const;
+	//void GetMonitorInfo(IHeadMountedDisplay::MonitorInfo& MonitorDesc) const;
 
 	// Helper function
 	// IPD    = ABS(GetLocation(LEFT_EYE).X - GetLocation(RIGHT_EYE).X);
@@ -62,6 +63,10 @@ private:
 	OSVRHMDDescription(OSVRHMDDescription&);
 	OSVRHMDDescription& operator=(OSVRHMDDescription&);
 
+    void InitIPD(OSVR_DisplayConfig displayConfig);
+    void InitDisplaySize(OSVR_DisplayConfig displayConfig);
+
+    float m_ipd;
 	bool Valid;
 	void* Data;
 };

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMDDescription.h
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMDDescription.h
@@ -38,25 +38,25 @@ public:
 		RIGHT_EYE
 	};
 
-	//FVector2D GetDisplaySize(EEye Eye) const;
-	//FVector2D GetDisplayOrigin(EEye Eye) const;
-	//FVector2D GetFov(EEye Eye) const;
+	FVector2D GetDisplaySize(EEye Eye) const;
+	FVector2D GetDisplayOrigin(EEye Eye) const;
+	FVector2D GetFov(EEye Eye) const;
     FVector2D GetFov(OSVR_EyeCount Eye) const;
-	//FVector GetLocation(EEye Eye) const;
-	//FString GetPositionalTrackerInterface(EEye Eye) const;
+	FVector GetLocation(EEye Eye) const;
+	FString GetPositionalTrackerInterface(EEye Eye) const;
 
-	//FMatrix GetProjectionMatrix(EEye Eye) const;
+	FMatrix GetProjectionMatrix(EEye Eye) const;
 
-	//void GetMonitorInfo(IHeadMountedDisplay::MonitorInfo& MonitorDesc) const;
+	void GetMonitorInfo(IHeadMountedDisplay::MonitorInfo& MonitorDesc) const;
 
 	// Helper function
 	// IPD    = ABS(GetLocation(LEFT_EYE).X - GetLocation(RIGHT_EYE).X);
-	//float GetInterpupillaryDistance() const;
+	float GetInterpupillaryDistance() const;
 
 	// Helper function
 	// Width  = GetDisplaySize(LEFT_EYE).X + GetDisplaySize(RIGHT_EYE).X;
 	// Height = MAX(GetDisplaySize(LEFT_EYE).Y, GetDisplaySize(RIGHT_EYE).Y);
-	//FVector2D GetResolution() const;
+	FVector2D GetResolution() const;
 
 private:
 	OSVRHMDDescription(OSVRHMDDescription&);

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMDDescription.h
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMDDescription.h
@@ -20,7 +20,6 @@
 
 #include <osvr/ClientKit/DisplayC.h>
 
-#include <cmath>
 
 class OSVRHMDDescription
 {

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMDDescription.h
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMDDescription.h
@@ -45,10 +45,7 @@ public:
 	FVector2D GetFov(EEye Eye) const;
     FVector2D GetFov(OSVR_EyeCount Eye) const;
 	FVector GetLocation(EEye Eye) const;
-
 	FMatrix GetProjectionMatrix(EEye Eye) const;
-
-	//void GetMonitorInfo(IHeadMountedDisplay::MonitorInfo& MonitorDesc) const;
 
 	// Helper function
 	// IPD    = ABS(GetLocation(LEFT_EYE).X - GetLocation(RIGHT_EYE).X);
@@ -63,8 +60,10 @@ private:
 	OSVRHMDDescription(OSVRHMDDescription&);
 	OSVRHMDDescription& operator=(OSVRHMDDescription&);
 
+    bool OSVRViewerFitsUnrealModel(OSVR_DisplayConfig displayConfig);
     void InitIPD(OSVR_DisplayConfig displayConfig);
     void InitDisplaySize(OSVR_DisplayConfig displayConfig);
+    void InitFOV(OSVR_DisplayConfig displayConfig);
 
     float m_ipd;
 	bool Valid;

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRTypes.h
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRTypes.h
@@ -30,3 +30,12 @@ FORCEINLINE FQuat OSVR2FQuat(const OSVR_Quaternion& Quat)
 	//q = q * FQuat(FVector(0, 1, 0), -15 * PI / 180);
 	return q;
 }
+
+// Assumes row-major, left-handed matrix
+FORCEINLINE FMatrix OSVR2FMatrix(const float in[16]) {
+    return FMatrix(
+        FPlane(in[0], in[1], in[2], in[3]),
+        FPlane(in[4], in[5], in[6], in[7]),
+        FPlane(in[8], in[9], in[10], in[11]),
+        FPlane(in[12], in[13], in[14], in[15]));
+}


### PR DESCRIPTION
This replaces the code that manually parsed the display config json from the server with calls to the DisplayConfig API. We are still calculating our own projection matrix, but we're basing it off of the FOV values from the DisplayConfig API (calculated from the clipping planes).
