### PR TITLE
Error handling and render-manager fallback

### DIFF
--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/OSVR.Build.cs
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/OSVR.Build.cs
@@ -42,6 +42,8 @@ public class OSVR : ModuleRules
                 new string[] {
  					        @"C:\Program Files\Epic Games\4.9\Engine\Source\Runtime\Windows\D3D11RHI\Private",
  					        @"C:\Program Files\Epic Games\4.9\Engine\Source\Runtime\Windows\D3D11RHI\Private\Windows",
+                            @"D:\unreal\Epic Games\4.9\Engine\Source\Runtime\Windows\D3D11RHI\Private",
+ 					        @"D:\unreal\Epic Games\4.9\Engine\Source\Runtime\Windows\D3D11RHI\Private\Windows",
     				        });
         //}
     }

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.cpp
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.cpp
@@ -52,7 +52,19 @@ bool FOSVRHMD::IsHMDConnected()
 
 bool FOSVRHMD::IsHMDEnabled() const
 {
-    return bHmdEnabled;
+    bool ret = false;
+    if (bHmdEnabled) {
+        size_t numTries = bWaitedForClientStatus ? 0 : 10000;
+        bool failure = false;
+        while (numTries-- > 0 && !ret && !failure) {
+            ret = osvrClientCheckStatus(osvrClientContext) == OSVR_RETURN_SUCCESS;
+            if (!ret) {
+                failure = osvrClientUpdate(osvrClientContext) == OSVR_RETURN_FAILURE;
+            }
+        }
+        ret = ret && !failure;
+    }
+    return ret;
 }
 
 void FOSVRHMD::EnableHMD(bool enable)

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.cpp
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.cpp
@@ -345,7 +345,7 @@ bool FOSVRHMD::EnableStereo(bool stereo)
 
 void FOSVRHMD::AdjustViewRect(EStereoscopicPass StereoPass, int32& X, int32& Y, uint32& SizeX, uint32& SizeY) const
 {
-    if (mCustomPresent) {
+    if (mCustomPresent && mCustomPresent->IsInitialized()) {
         mCustomPresent->CalculateRenderTargetSize(SizeX, SizeY);
     }
     SizeX = SizeX / 2;
@@ -625,6 +625,10 @@ FOSVRHMD::~FOSVRHMD()
     EnablePositionalTracking(false);
     if (DisplayConfig) {
         osvrClientFreeDisplay(DisplayConfig);
+    }
+
+    if (mCustomPresent) {
+        delete mCustomPresent;
     }
 }
 

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.cpp
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.cpp
@@ -64,6 +64,7 @@ bool FOSVRHMD::IsHMDEnabled() const
         }
         ret = ret && !failure;
     }
+    // TODO: we also need to check that there actually is an interface at /me/head
     return ret;
 }
 

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.h
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.h
@@ -593,6 +593,7 @@ private:
 
   bool bStereoEnabled;
   bool bHmdEnabled;
+  bool bHmdConnected;
   bool bHmdOverridesApplied;
   bool bWaitedForClientStatus = false;
   

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.h
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.h
@@ -41,6 +41,9 @@
 #include <set>
 #include <vector>
 
+DECLARE_LOG_CATEGORY_EXTERN(OSVRHMDLog, Log, All);
+DECLARE_LOG_CATEGORY_EXTERN(FOSVRCustomPresentLog, Log, All);
+
 //class ID3D11Device;
 //class ID3D11DeviceContext;
 
@@ -60,6 +63,10 @@ public:
     virtual ~FOSVRCustomPresent() {
         if (mClientContext) {
             osvrClientShutdown(mClientContext);
+        }
+
+        if (mRenderManager) {
+            osvrDestroyRenderManager(mRenderManager);
         }
     }
 

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.h
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.h
@@ -594,6 +594,7 @@ private:
   bool bStereoEnabled;
   bool bHmdEnabled;
   bool bHmdOverridesApplied;
+  bool bWaitedForClientStatus = false;
   
   OSVRHMDDescription HMDDescription;
   OSVR_DisplayConfig DisplayConfig;

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.h
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.h
@@ -92,13 +92,13 @@ public:
         return mInitialized;
     }
 
-    virtual void UpdateViewport(const FViewport& InViewport, class FRHIViewport* InViewportRHI) = 0;
+    virtual bool UpdateViewport(const FViewport& InViewport, class FRHIViewport* InViewportRHI) = 0;
 
     // RenderManager normalizes displays a bit. We create the render target assuming horizontal side-by-side.
     // RenderManager then rotates that render texture if needed for vertical side-by-side displays.
-    virtual void CalculateRenderTargetSize(uint32& InOutSizeX, uint32& InOutSizeY) {
+    virtual bool CalculateRenderTargetSize(uint32& InOutSizeX, uint32& InOutSizeY) {
         FScopeLock lock(&mOSVRMutex);
-        CalculateRenderTargetSizeImpl(InOutSizeX, InOutSizeY);
+        return CalculateRenderTargetSizeImpl(InOutSizeX, InOutSizeY);
     }
 
     virtual bool AllocateRenderTargetTexture(uint32 index, uint32 sizeX, uint32 sizeY, uint8 format, uint32 numMips, uint32 flags, uint32 targetableTextureFlags, FTexture2DRHIRef& outTargetableTexture, FTexture2DRHIRef& outShaderResourceTexture, uint32 numSamples = 1) = 0;
@@ -113,7 +113,7 @@ protected:
     OSVR_ClientContext mClientContext = nullptr;
     OSVR_RenderManager mRenderManager = nullptr;
 
-    virtual void CalculateRenderTargetSizeImpl(uint32& InOutSizeX, uint32& InOutSizeY) = 0;
+    virtual bool CalculateRenderTargetSizeImpl(uint32& InOutSizeX, uint32& InOutSizeY) = 0;
 
     virtual bool InitializeImpl() = 0;
 
@@ -139,103 +139,112 @@ public:
         FOSVRCustomPresent(clientContext)
     {}
 
-    virtual void UpdateViewport(const FViewport& InViewport, class FRHIViewport* InViewportRHI) override {
+    virtual bool UpdateViewport(const FViewport& InViewport, class FRHIViewport* InViewportRHI) override {
         FScopeLock lock(&mOSVRMutex);
 
         check(IsInGameThread());
-        check(InViewportRHI);
-        //const FTexture2DRHIRef& rt = InViewport.GetRenderTargetTexture();
-        //check(IsValidRef(rt));
-        //SetRenderTargetTexture((ID3D11Texture2D*)rt->GetNativeResource()); // @todo: do we need to do this?
-        auto oldCustomPresent = InViewportRHI->GetCustomPresent();
-        if (oldCustomPresent != this) {
-            InViewportRHI->SetCustomPresent(this);
+        if (!IsInitialized()) {
+            UE_LOG(OSVRHMDLog, Warning, TEXT("UpdateViewport called but custom present is not initialized - doing nothing"));
+            return false;
+        } else {
+            check(InViewportRHI);
+            //const FTexture2DRHIRef& rt = InViewport.GetRenderTargetTexture();
+            //check(IsValidRef(rt));
+            //SetRenderTargetTexture((ID3D11Texture2D*)rt->GetNativeResource()); // @todo: do we need to do this?
+            auto oldCustomPresent = InViewportRHI->GetCustomPresent();
+            if (oldCustomPresent != this) {
+                InViewportRHI->SetCustomPresent(this);
+            }
+            // UpdateViewport is called before we're initialized, so we have to
+            // defer updates to the render buffers until we're in the render thread.
+            //mRenderBuffersNeedToUpdate = true;
+            return true;
         }
-        // UpdateViewport is called before we're initialized, so we have to
-        // defer updates to the render buffers until we're in the render thread.
-        //mRenderBuffersNeedToUpdate = true;
     }
 
     virtual bool AllocateRenderTargetTexture(uint32 index, uint32 sizeX, uint32 sizeY, uint8 format, uint32 numMips, uint32 flags, uint32 targetableTextureFlags, FTexture2DRHIRef& outTargetableTexture, FTexture2DRHIRef& outShaderResourceTexture, uint32 numSamples = 1) override {
         FScopeLock lock(&mOSVRMutex);
-        auto d3d11RHI = static_cast<FD3D11DynamicRHI*>(GDynamicRHI);
-        auto graphicsDevice = GetGraphicsDevice();
-        HRESULT hr;
-        D3D11_TEXTURE2D_DESC textureDesc;
-        memset(&textureDesc, 0, sizeof(textureDesc));
-        textureDesc.Width = sizeX;
-        textureDesc.Height = sizeY;
-        textureDesc.MipLevels = 1;
-        textureDesc.ArraySize = 1;
-        //textureDesc.Format = DXGI_FORMAT_R32G32B32A32_FLOAT;
-        textureDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-        textureDesc.SampleDesc.Count = 1;
-        textureDesc.SampleDesc.Quality = 0;
-        textureDesc.Usage = D3D11_USAGE_DEFAULT;
-        // We need it to be both a render target and a shader resource
-        textureDesc.BindFlags = D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE;
-        textureDesc.CPUAccessFlags = 0;
-        textureDesc.MiscFlags = 0;
+        if (IsInitialized()) {
+            auto d3d11RHI = static_cast<FD3D11DynamicRHI*>(GDynamicRHI);
+            auto graphicsDevice = GetGraphicsDevice();
+            HRESULT hr;
+            D3D11_TEXTURE2D_DESC textureDesc;
+            memset(&textureDesc, 0, sizeof(textureDesc));
+            textureDesc.Width = sizeX;
+            textureDesc.Height = sizeY;
+            textureDesc.MipLevels = 1;
+            textureDesc.ArraySize = 1;
+            //textureDesc.Format = DXGI_FORMAT_R32G32B32A32_FLOAT;
+            textureDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+            textureDesc.SampleDesc.Count = 1;
+            textureDesc.SampleDesc.Quality = 0;
+            textureDesc.Usage = D3D11_USAGE_DEFAULT;
+            // We need it to be both a render target and a shader resource
+            textureDesc.BindFlags = D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE;
+            textureDesc.CPUAccessFlags = 0;
+            textureDesc.MiscFlags = 0;
 
-        ID3D11Texture2D *D3DTexture = nullptr;
-        hr = graphicsDevice->CreateTexture2D(
-            &textureDesc, NULL, &D3DTexture);
-        check(!FAILED(hr));
+            ID3D11Texture2D *D3DTexture = nullptr;
+            hr = graphicsDevice->CreateTexture2D(
+                &textureDesc, NULL, &D3DTexture);
+            check(!FAILED(hr));
 
-        SetRenderTargetTexture(D3DTexture);
+            SetRenderTargetTexture(D3DTexture);
 
-        D3D11_RENDER_TARGET_VIEW_DESC renderTargetViewDesc;
-        memset(&renderTargetViewDesc, 0, sizeof(renderTargetViewDesc));
-        // This must match what was created in the texture to be rendered
-        //renderTargetViewDesc.Format = renderTextureDesc.Format;
-        renderTargetViewDesc.Format = textureDesc.Format;
-        renderTargetViewDesc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2D;
-        renderTargetViewDesc.Texture2D.MipSlice = 0;
+            D3D11_RENDER_TARGET_VIEW_DESC renderTargetViewDesc;
+            memset(&renderTargetViewDesc, 0, sizeof(renderTargetViewDesc));
+            // This must match what was created in the texture to be rendered
+            //renderTargetViewDesc.Format = renderTextureDesc.Format;
+            renderTargetViewDesc.Format = textureDesc.Format;
+            renderTargetViewDesc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2D;
+            renderTargetViewDesc.Texture2D.MipSlice = 0;
 
-        // Create the render target view.
-        ID3D11RenderTargetView *renderTargetView; //< Pointer to our render target view
-        hr = graphicsDevice->CreateRenderTargetView(
-            RenderTargetTexture, &renderTargetViewDesc, &renderTargetView);
-        check(!FAILED(hr));
+            // Create the render target view.
+            ID3D11RenderTargetView *renderTargetView; //< Pointer to our render target view
+            hr = graphicsDevice->CreateRenderTargetView(
+                RenderTargetTexture, &renderTargetViewDesc, &renderTargetView);
+            check(!FAILED(hr));
 
-        RenderTargetView = renderTargetView;
+            RenderTargetView = renderTargetView;
 
-        ID3D11ShaderResourceView* shaderResourceView = nullptr;
-        bool createdRTVsPerSlice = false;
-        int32 rtvArraySize = 1;
-        TArray<TRefCountPtr<ID3D11RenderTargetView>> renderTargetViews;
-        TRefCountPtr<ID3D11DepthStencilView>* depthStencilViews = nullptr;
-        uint32 sizeZ = 0;
-        EPixelFormat epFormat = EPixelFormat(format);
-        bool cubemap = false;
-        bool pooled = false;
-        // override flags
-        flags = TexCreate_RenderTargetable | TexCreate_ShaderResource;
+            ID3D11ShaderResourceView* shaderResourceView = nullptr;
+            bool createdRTVsPerSlice = false;
+            int32 rtvArraySize = 1;
+            TArray<TRefCountPtr<ID3D11RenderTargetView>> renderTargetViews;
+            TRefCountPtr<ID3D11DepthStencilView>* depthStencilViews = nullptr;
+            uint32 sizeZ = 0;
+            EPixelFormat epFormat = EPixelFormat(format);
+            bool cubemap = false;
+            bool pooled = false;
+            // override flags
+            flags = TexCreate_RenderTargetable | TexCreate_ShaderResource;
 
-        renderTargetViews.Add(renderTargetView);
-        D3D11_SHADER_RESOURCE_VIEW_DESC shaderResourceViewDesc;
-        memset(&shaderResourceViewDesc, 0, sizeof(shaderResourceViewDesc));
-        shaderResourceViewDesc.Format = textureDesc.Format;
-        shaderResourceViewDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
-        shaderResourceViewDesc.Texture2D.MipLevels = textureDesc.MipLevels;
-        shaderResourceViewDesc.Texture2D.MostDetailedMip = textureDesc.MipLevels - 1;
+            renderTargetViews.Add(renderTargetView);
+            D3D11_SHADER_RESOURCE_VIEW_DESC shaderResourceViewDesc;
+            memset(&shaderResourceViewDesc, 0, sizeof(shaderResourceViewDesc));
+            shaderResourceViewDesc.Format = textureDesc.Format;
+            shaderResourceViewDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+            shaderResourceViewDesc.Texture2D.MipLevels = textureDesc.MipLevels;
+            shaderResourceViewDesc.Texture2D.MostDetailedMip = textureDesc.MipLevels - 1;
 
-        hr = graphicsDevice->CreateShaderResourceView(
-            RenderTargetTexture, &shaderResourceViewDesc, &shaderResourceView);
-        check(!FAILED(hr));
+            hr = graphicsDevice->CreateShaderResourceView(
+                RenderTargetTexture, &shaderResourceViewDesc, &shaderResourceView);
+            check(!FAILED(hr));
 
-        auto targetableTexture = new FD3D11Texture2D(
-            d3d11RHI, D3DTexture, shaderResourceView, createdRTVsPerSlice,
-            rtvArraySize, renderTargetViews, depthStencilViews,
-            textureDesc.Width, textureDesc.Height, sizeZ, numMips, numSamples, epFormat,
-            cubemap, flags, pooled, FClearValueBinding::Black);
+            auto targetableTexture = new FD3D11Texture2D(
+                d3d11RHI, D3DTexture, shaderResourceView, createdRTVsPerSlice,
+                rtvArraySize, renderTargetViews, depthStencilViews,
+                textureDesc.Width, textureDesc.Height, sizeZ, numMips, numSamples, epFormat,
+                cubemap, flags, pooled, FClearValueBinding::Black);
 
-        outTargetableTexture = targetableTexture->GetTexture2D();
-        outShaderResourceTexture = targetableTexture->GetTexture2D();
-        mRenderTexture = targetableTexture;
-        mRenderBuffersNeedToUpdate = true;
-        UpdateRenderBuffers();
-        return true;
+            outTargetableTexture = targetableTexture->GetTexture2D();
+            outShaderResourceTexture = targetableTexture->GetTexture2D();
+            mRenderTexture = targetableTexture;
+            mRenderBuffersNeedToUpdate = true;
+            UpdateRenderBuffers();
+            return true;
+        }
+        return false;
     }
 
 protected:
@@ -246,33 +255,36 @@ protected:
     std::vector<OSVR_RenderInfoD3D11> mRenderInfos;
     OSVR_RenderManagerD3D11 mRenderManagerD3D11 = nullptr;
 
-    virtual void CalculateRenderTargetSizeImpl(uint32& InOutSizeX, uint32& InOutSizeY) override {
-        InitializeImpl();
-        // Should we create a RenderParams?
-        OSVR_ReturnCode rc;
+    virtual bool CalculateRenderTargetSizeImpl(uint32& InOutSizeX, uint32& InOutSizeY) override {
+        if (InitializeImpl()) {
+            // Should we create a RenderParams?
+            OSVR_ReturnCode rc;
 
-        rc = osvrRenderManagerGetDefaultRenderParams(&mRenderParams);
-        check(rc == OSVR_RETURN_SUCCESS);
-
-        OSVR_RenderInfoCount numRenderInfo;
-        rc = osvrRenderManagerGetNumRenderInfo(mRenderManager, mRenderParams, &numRenderInfo);
-        check(rc == OSVR_RETURN_SUCCESS);
-
-        mRenderInfos.clear();
-        for (size_t i = 0; i < numRenderInfo; i++) {
-            OSVR_RenderInfoD3D11 renderInfo;
-            rc = osvrRenderManagerGetRenderInfoD3D11(mRenderManagerD3D11, i, mRenderParams, &renderInfo);
+            rc = osvrRenderManagerGetDefaultRenderParams(&mRenderParams);
             check(rc == OSVR_RETURN_SUCCESS);
 
-            mRenderInfos.push_back(renderInfo);
-        }
+            OSVR_RenderInfoCount numRenderInfo;
+            rc = osvrRenderManagerGetNumRenderInfo(mRenderManager, mRenderParams, &numRenderInfo);
+            check(rc == OSVR_RETURN_SUCCESS);
 
-        // check some assumptions. Should all be the same height.
-        check(mRenderInfos.size() == 2);
-        check(mRenderInfos[0].viewport.height == mRenderInfos[1].viewport.height);
-        InOutSizeX = mRenderInfos[0].viewport.width + mRenderInfos[1].viewport.width;
-        InOutSizeY = mRenderInfos[0].viewport.height;
-        check(InOutSizeX != 0 && InOutSizeY != 0);
+            mRenderInfos.clear();
+            for (size_t i = 0; i < numRenderInfo; i++) {
+                OSVR_RenderInfoD3D11 renderInfo;
+                rc = osvrRenderManagerGetRenderInfoD3D11(mRenderManagerD3D11, i, mRenderParams, &renderInfo);
+                check(rc == OSVR_RETURN_SUCCESS);
+
+                mRenderInfos.push_back(renderInfo);
+            }
+
+            // check some assumptions. Should all be the same height.
+            check(mRenderInfos.size() == 2);
+            check(mRenderInfos[0].viewport.height == mRenderInfos[1].viewport.height);
+            InOutSizeX = mRenderInfos[0].viewport.width + mRenderInfos[1].viewport.width;
+            InOutSizeY = mRenderInfos[0].viewport.height;
+            check(InOutSizeX != 0 && InOutSizeY != 0);
+            return true;
+        }
+        return false;
     }
 
     virtual bool InitializeImpl() override {

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMDDescription.h
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMDDescription.h
@@ -20,6 +20,7 @@
 
 #include <osvr/ClientKit/DisplayC.h>
 
+DECLARE_LOG_CATEGORY_EXTERN(OSVRHMDDescriptionLog, Log, All);
 
 class OSVRHMDDescription
 {
@@ -45,6 +46,7 @@ public:
     FVector2D GetFov(OSVR_EyeCount Eye) const;
 	FVector GetLocation(EEye Eye) const;
 	FMatrix GetProjectionMatrix(EEye Eye, OSVR_DisplayConfig displayConfig) const;
+    bool OSVRViewerFitsUnrealModel(OSVR_DisplayConfig displayConfig);
 
 	// Helper function
 	// IPD    = ABS(GetLocation(LEFT_EYE).X - GetLocation(RIGHT_EYE).X);
@@ -59,10 +61,9 @@ private:
 	OSVRHMDDescription(OSVRHMDDescription&);
 	OSVRHMDDescription& operator=(OSVRHMDDescription&);
 
-    bool OSVRViewerFitsUnrealModel(OSVR_DisplayConfig displayConfig);
-    void InitIPD(OSVR_DisplayConfig displayConfig);
-    void InitDisplaySize(OSVR_DisplayConfig displayConfig);
-    void InitFOV(OSVR_DisplayConfig displayConfig);
+    bool InitIPD(OSVR_DisplayConfig displayConfig);
+    bool InitDisplaySize(OSVR_DisplayConfig displayConfig);
+    bool InitFOV(OSVR_DisplayConfig displayConfig);
 
     float m_ipd;
 	bool Valid;


### PR DESCRIPTION
Implements https://github.com/OSVR/OSVR-Unreal/issues/34

RenderManager fallback is a little tricky because the RenderManager needs to be initialized in the render thread, so it can't be initialized in the OSVRHMD constructor, but there isn't a hook for "Initialize render thread stuff" in the HMD interface that I'm aware of (something to research). I initialize it in the first method that is called that requires the render manager to be initialized and is on the render thread, which is the method to calculate the render target size.
