### PR TITLE
Auto-detect engine source location for adding private header includes.

### DIFF
--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/OSVR.Build.cs
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/OSVR.Build.cs
@@ -1,4 +1,5 @@
 using UnrealBuildTool;
+using System.IO;
 
 public class OSVR : ModuleRules
 {
@@ -38,13 +39,14 @@ public class OSVR : ModuleRules
         if(Target.Platform == UnrealTargetPlatform.Win32 || Target.Platform == UnrealTargetPlatform.Win64)
         {
             PrivateDependencyModuleNames.AddRange(new string[] { "D3D11RHI" });
+
+            // Required for some private headers needed for the rendering support.
+            var EngineDir = Path.GetFullPath(BuildConfiguration.RelativeEnginePath);
             PrivateIncludePaths.AddRange(
                 new string[] {
- 					        @"C:\Program Files\Epic Games\4.10\Engine\Source\Runtime\Windows\D3D11RHI\Private",
- 					        @"C:\Program Files\Epic Games\4.10\Engine\Source\Runtime\Windows\D3D11RHI\Private\Windows",
-                            @"D:\unreal\Epic Games\4.10\Engine\Source\Runtime\Windows\D3D11RHI\Private",
- 					        @"D:\unreal\Epic Games\4.10\Engine\Source\Runtime\Windows\D3D11RHI\Private\Windows",
-    				        });
+                            Path.Combine(EngineDir, @"Source\Runtime\Windows\D3D11RHI\Private"),
+                            Path.Combine(EngineDir, @"Source\Runtime\Windows\D3D11RHI\Private\Windows")
+                            });
         }
     }
 }


### PR DESCRIPTION
Avoids need for user to modify build files based on their engine location
just because we have to include some private headers to get to the rendering
code we need. We can get to those paths with the build tool.
