### PR TITLE
Input shared context

### DIFF
--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVREntryPoint.cpp
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVREntryPoint.cpp
@@ -22,8 +22,6 @@
 
 #include "OSVREntryPoint.h"
 
-OSVR_ClientContext osvrClientContext(nullptr);
-
 OSVREntryPoint::OSVREntryPoint()
 {
 	osvrClientContext = osvrClientInit("com.osvr.unreal.plugin");

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVREntryPoint.h
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVREntryPoint.h
@@ -23,6 +23,7 @@
 OSVR_API class OSVREntryPoint : public FTickableGameObject
 {
 public:
+
 	OSVREntryPoint();
 	virtual ~OSVREntryPoint();
 
@@ -44,10 +45,20 @@ public:
 	{
 		RETURN_QUICK_DECLARE_CYCLE_STAT(OSVREntryPoint, STATGROUP_Tickables);
 	}
+
+    virtual OSVR_ClientContext GetClientContext()
+    {
+        return osvrClientContext;
+    }
+
 #if OSVR_DEPRECATED_BLUEPRINT_API_ENABLED
 	OSVRInterfaceCollection* GetInterfaceCollection();
+#endif
 
 private:
+    OSVR_ClientContext osvrClientContext = nullptr;
+
+#if OSVR_DEPRECATED_BLUEPRINT_API_ENABLED
 	TSharedPtr< OSVRInterfaceCollection > InterfaceCollection;
 #endif
 };

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.cpp
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.cpp
@@ -20,6 +20,7 @@
 #include "OSVRTypes.h"
 #include "SharedPointer.h"
 #include "SceneViewport.h"
+#include "OSVREntryPoint.h"
 
 #if WITH_EDITOR
 #include "Editor/UnrealEd/Classes/Editor/EditorEngine.h"
@@ -37,8 +38,6 @@
 #include <osvr/Util/MatrixConventionsC.h>
 #include <cmath>
 #include <vector>
-
-extern OSVR_ClientContext osvrClientContext;
 
 DEFINE_LOG_CATEGORY(OSVRHMDLog);
 
@@ -114,7 +113,7 @@ void FOSVRHMD::UpdateHeadPose() {
     OSVR_Pose3 pose;
     OSVR_ReturnCode returnCode;
 
-    returnCode = osvrClientUpdate(osvrClientContext);
+    returnCode = osvrClientUpdate(IOSVR::Get().GetEntryPoint()->GetClientContext());
     check(returnCode == OSVR_RETURN_SUCCESS);
 
     returnCode = osvrClientGetViewerPose(DisplayConfig, 0, &pose);
@@ -556,6 +555,7 @@ FOSVRHMD::FOSVRHMD()
 {
     static const FName RendererModuleName("Renderer");
     RendererModule = FModuleManager::GetModulePtr<IRendererModule>(RendererModuleName);
+    OSVR_ClientContext osvrClientContext = IOSVR::Get().GetEntryPoint()->GetClientContext();
 
     FSystemResolution::RequestResolutionChange(1280, 720, EWindowMode::Windowed); // bStereo ? WindowedMirror : Windowed
 
@@ -581,7 +581,7 @@ FOSVRHMD::FOSVRHMD()
 
     // check if the client context is ok.
     bool clientContextOK = false;
-    {
+    {  
         size_t numTries = 0;
         bool failure = false;
         while (numTries++ < 10000 && !clientContextOK && !failure) {

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVRInput/Private/OSVRInputDevice.cpp
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVRInput/Private/OSVRInputDevice.cpp
@@ -49,8 +49,6 @@ namespace {
 }
 
 class OSVRButton {
-private:
-    OSVR_ClientContext context;
 
 public:
     OSVRButton() {}
@@ -108,7 +106,7 @@ FOSVRInputDevice::FOSVRInputDevice(const TSharedRef< FGenericApplicationMessageH
     : MessageHandler(InMessageHandler)
 {
     // make sure OSVR module is loaded.
-    context = osvrClientInit("com.osvr.unreal.plugin.input");
+    context = IOSVR::Get().GetEntryPoint()->GetClientContext();
 
     const float defaultThreshold = 0.25f;
 
@@ -244,7 +242,6 @@ FOSVRInputDevice::~FOSVRInputDevice()
                 osvrClientFreeInterface(context, iface.second);
             }
         }
-        osvrClientShutdown(context);
     }
 }
 


### PR DESCRIPTION
OSVRInput should share the client context with OSVRHMD. In addition, the osvrClientContext global should be moved into OSVREntryPoint instead of being referenced as an extern global.
