### PR TITLE
Render info change

### DIFF
--- a/OSVRUnreal/Config/DefaultEngine.ini
+++ b/OSVRUnreal/Config/DefaultEngine.ini
@@ -3,6 +3,7 @@
 bFullScreen=True
 
 [/Script/Engine.RendererSettings]
+r.screenpercentage=100
 r.MobileHDR=True
 r.MobileNumDynamicPointLights=4
 r.MobileDynamicPointLightsUseStaticBranch=True

--- a/OSVRUnreal/Config/DefaultGameUserSettings.ini
+++ b/OSVRUnreal/Config/DefaultGameUserSettings.ini
@@ -1,9 +1,9 @@
 [/Script/Engine.GameUserSettings]
 bUseVSync=True
-ResolutionSizeX=2560
-ResolutionSizeY=1440
-LastUserConfirmedResolutionSizeX=2560
-LastUserConfirmedResolutionSizeY=1440
+ResolutionSizeX=1920
+ResolutionSizeY=1080
+LastUserConfirmedResolutionSizeX=1920
+LastUserConfirmedResolutionSizeY=1080
 WindowPosX=-1
 WindowPosY=-1
 bUseDesktopResolutionForFullscreen=True

--- a/OSVRUnreal/OSVRUnreal.uproject
+++ b/OSVRUnreal/OSVRUnreal.uproject
@@ -1,8 +1,15 @@
 {
 	"FileVersion": 3,
-	"EngineAssociation": "4.11",
+	"EngineAssociation": "4.12",
 	"Category": "",
 	"Description": "",
+	"Modules": [
+		{
+			"Name": "OSVRUnreal",
+			"Type": "Runtime",
+			"LoadingPhase": "Default"
+		}
+	],
 	"Plugins": [
 		{
 			"Name": "OculusRift",

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRCustomPresent.h
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRCustomPresent.h
@@ -92,7 +92,7 @@ public:
         return bInitialized;
     }
 
-    virtual void GetProjectionMatrix(OSVR_RenderInfoCount eye, double &left, double &right, double &bottom, double &top, double nearClip, double farClip) = 0;
+    virtual void GetProjectionMatrix(OSVR_RenderInfoCount eye, float &left, float &right, float &bottom, float &top, float nearClip, float farClip) = 0;
     virtual bool UpdateViewport(const FViewport& InViewport, class FRHIViewport* InViewportRHI) = 0;
 
     // RenderManager normalizes displays a bit. We create the render target assuming horizontal side-by-side.

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRCustomPresent.h
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRCustomPresent.h
@@ -116,6 +116,7 @@ protected:
     float mScreenScale = 1.0f;
     OSVR_ClientContext mClientContext = nullptr;
     OSVR_RenderManager mRenderManager = nullptr;
+    OSVR_RenderInfoCollection mCachedRenderInfoCollection = nullptr;
 
     virtual bool CalculateRenderTargetSizeImpl(uint32& InOutSizeX, uint32& InOutSizeY) = 0;
 

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRCustomPresent.h
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRCustomPresent.h
@@ -92,7 +92,7 @@ public:
         return bInitialized;
     }
 
-    virtual void GetProjectionMatrix(OSVR_RenderInfoCount eye, double &left, double &right, double &bottom, double &top) = 0;
+    virtual void GetProjectionMatrix(OSVR_RenderInfoCount eye, double &left, double &right, double &bottom, double &top, double nearClip, double farClip) = 0;
     virtual bool UpdateViewport(const FViewport& InViewport, class FRHIViewport* InViewportRHI) = 0;
 
     // RenderManager normalizes displays a bit. We create the render target assuming horizontal side-by-side.

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRCustomPresentD3D11.h
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRCustomPresentD3D11.h
@@ -159,14 +159,14 @@ public:
     }
 
 
-    virtual void GetProjectionMatrix(OSVR_RenderInfoCount eye, double &left, double &right, double &bottom, double &top, double nearClip, double farClip) override
+    virtual void GetProjectionMatrix(OSVR_RenderInfoCount eye, float &left, float &right, float &bottom, float &top, float nearClip, float farClip) override
     {
         OSVR_ReturnCode rc;
         rc = osvrRenderManagerGetDefaultRenderParams(&mRenderParams);
         check(rc == OSVR_RETURN_SUCCESS);
 
-        mRenderParams.nearClipDistanceMeters = nearClip;
-        mRenderParams.farClipDistanceMeters = farClip;
+        mRenderParams.nearClipDistanceMeters = static_cast<double>(nearClip);
+        mRenderParams.farClipDistanceMeters = static_cast<double>(farClip);
 
         // this method gets called with alternating eyes starting with the left. We get the render info when
         // the left eye (index 0) is requested (releasing the old one, if any),
@@ -187,10 +187,10 @@ public:
         // previously we divided these by renderInfo.projection.nearClip but we need
         // to pass these unmodified through to the OSVR_Projection_to_D3D call (and OpenGL
         // equivalent)
-        left = renderInfo.projection.left;
-        right = renderInfo.projection.right;
-        top = renderInfo.projection.top;
-        bottom = renderInfo.projection.bottom;
+        left = static_cast<float>(renderInfo.projection.left);
+        right = static_cast<float>(renderInfo.projection.right);
+        top = static_cast<float>(renderInfo.projection.top);
+        bottom = static_cast<float>(renderInfo.projection.bottom);
     }
 
 protected:

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRCustomPresentD3D11.h
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRCustomPresentD3D11.h
@@ -159,13 +159,15 @@ public:
     }
 
 
-    virtual void GetProjectionMatrix(OSVR_RenderInfoCount eye, double &left, double &right, double &bottom, double &top) override
+    virtual void GetProjectionMatrix(OSVR_RenderInfoCount eye, double &left, double &right, double &bottom, double &top, double nearClip, double farClip) override
     {
         OSVR_ReturnCode rc;
         rc = osvrRenderManagerGetDefaultRenderParams(&mRenderParams);
         check(rc == OSVR_RETURN_SUCCESS);
 
-        mRenderParams.farClipDistanceMeters = 10000.0f;
+        mRenderParams.nearClipDistanceMeters = nearClip;
+        mRenderParams.farClipDistanceMeters = farClip;
+
         // this method gets called with alternating eyes starting with the left. We get the render info when
         // the left eye (index 0) is requested (releasing the old one, if any),
         // and re-use the same collection when the right eye (index 0) is requested
@@ -182,14 +184,13 @@ public:
         rc = osvrRenderManagerGetRenderInfoFromCollectionD3D11(mCachedRenderInfoCollection, eye, &renderInfo);
         check(rc == OSVR_RETURN_SUCCESS);
 
-        //OSVR_RenderInfoD3D11 renderInfo;
-        //rc = osvrRenderManagerGetRenderInfoD3D11(mRenderManagerD3D11, eye, mRenderParams, &renderInfo);
-        //check(rc == OSVR_RETURN_SUCCESS);
-
-        left = renderInfo.projection.left;// / renderInfo.projection.nearClip;
-        right = renderInfo.projection.right;// / renderInfo.projection.nearClip;
-        top = renderInfo.projection.top;// / renderInfo.projection.nearClip;
-        bottom = renderInfo.projection.bottom;// / renderInfo.projection.nearClip;
+        // previously we divided these by renderInfo.projection.nearClip but we need
+        // to pass these unmodified through to the OSVR_Projection_to_D3D call (and OpenGL
+        // equivalent)
+        left = renderInfo.projection.left;
+        right = renderInfo.projection.right;
+        top = renderInfo.projection.top;
+        bottom = renderInfo.projection.bottom;
     }
 
 protected:

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRCustomPresentD3D11.h
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRCustomPresentD3D11.h
@@ -165,9 +165,25 @@ public:
         rc = osvrRenderManagerGetDefaultRenderParams(&mRenderParams);
         check(rc == OSVR_RETURN_SUCCESS);
 
+        if (eye == 0) {
+            if (mCachedRenderInfoCollection) {
+                rc = osvrRenderManagerReleaseRenderInfoCollection(mCachedRenderInfoCollection);
+                check(rc == OSVR_RETURN_SUCCESS);
+            }
+            rc = osvrRenderManagerGetRenderInfoCollection(mRenderManager, mRenderParams, &mCachedRenderInfoCollection);
+            check(rc == OSVR_RETURN_SUCCESS);
+        }
+
         OSVR_RenderInfoD3D11 renderInfo;
-        rc = osvrRenderManagerGetRenderInfoD3D11(mRenderManagerD3D11, eye, mRenderParams, &renderInfo);
+        rc = osvrRenderManagerGetRenderInfoFromCollectionD3D11(mCachedRenderInfoCollection, eye, &renderInfo);
         check(rc == OSVR_RETURN_SUCCESS);
+
+        rc = osvrRenderManagerReleaseRenderInfoCollection(mCachedRenderInfoCollection);
+        check(rc == OSVR_RETURN_SUCCESS);
+
+        //OSVR_RenderInfoD3D11 renderInfo;
+        //rc = osvrRenderManagerGetRenderInfoD3D11(mRenderManagerD3D11, eye, mRenderParams, &renderInfo);
+        //check(rc == OSVR_RETURN_SUCCESS);
 
         left = renderInfo.projection.left / renderInfo.projection.nearClip;
         right = renderInfo.projection.right / renderInfo.projection.nearClip;

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRCustomPresentD3D11.h
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRCustomPresentD3D11.h
@@ -165,6 +165,7 @@ public:
         rc = osvrRenderManagerGetDefaultRenderParams(&mRenderParams);
         check(rc == OSVR_RETURN_SUCCESS);
 
+        mRenderParams.farClipDistanceMeters = 10000.0f;
         // this method gets called with alternating eyes starting with the left. We get the render info when
         // the left eye (index 0) is requested (releasing the old one, if any),
         // and re-use the same collection when the right eye (index 0) is requested
@@ -185,10 +186,10 @@ public:
         //rc = osvrRenderManagerGetRenderInfoD3D11(mRenderManagerD3D11, eye, mRenderParams, &renderInfo);
         //check(rc == OSVR_RETURN_SUCCESS);
 
-        left = renderInfo.projection.left / renderInfo.projection.nearClip;
-        right = renderInfo.projection.right / renderInfo.projection.nearClip;
-        top = renderInfo.projection.top / renderInfo.projection.nearClip;
-        bottom = renderInfo.projection.bottom / renderInfo.projection.nearClip;
+        left = renderInfo.projection.left;// / renderInfo.projection.nearClip;
+        right = renderInfo.projection.right;// / renderInfo.projection.nearClip;
+        top = renderInfo.projection.top;// / renderInfo.projection.nearClip;
+        bottom = renderInfo.projection.bottom;// / renderInfo.projection.nearClip;
     }
 
 protected:

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRCustomPresentD3D11.h
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRCustomPresentD3D11.h
@@ -165,7 +165,10 @@ public:
         rc = osvrRenderManagerGetDefaultRenderParams(&mRenderParams);
         check(rc == OSVR_RETURN_SUCCESS);
 
-        if (eye == 0) {
+        // this method gets called with alternating eyes starting with the left. We get the render info when
+        // the left eye (index 0) is requested (releasing the old one, if any),
+        // and re-use the same collection when the right eye (index 0) is requested
+        if (eye == 0 || !mCachedRenderInfoCollection) {
             if (mCachedRenderInfoCollection) {
                 rc = osvrRenderManagerReleaseRenderInfoCollection(mCachedRenderInfoCollection);
                 check(rc == OSVR_RETURN_SUCCESS);
@@ -176,9 +179,6 @@ public:
 
         OSVR_RenderInfoD3D11 renderInfo;
         rc = osvrRenderManagerGetRenderInfoFromCollectionD3D11(mCachedRenderInfoCollection, eye, &renderInfo);
-        check(rc == OSVR_RETURN_SUCCESS);
-
-        rc = osvrRenderManagerReleaseRenderInfoCollection(mCachedRenderInfoCollection);
         check(rc == OSVR_RETURN_SUCCESS);
 
         //OSVR_RenderInfoD3D11 renderInfo;

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.cpp
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.cpp
@@ -644,11 +644,13 @@ FMatrix FOSVRHMD::GetStereoProjectionMatrix(enum EStereoscopicPass StereoPassTyp
     FMatrix ret;
     if (mCustomPresent)
     {
+        double nearClip = GNearClippingPlane;
+        double farClip = 1000000.0;
         double left, right, bottom, top;
         mCustomPresent->GetProjectionMatrix(
             StereoPassType == eSSP_LEFT_EYE ? 0 : 1,
-            left, right, bottom, top);
-        ret = HMDDescription.GetProjectionMatrix(left, right, bottom, top);
+            left, right, bottom, top, nearClip, farClip);
+        ret = HMDDescription.GetProjectionMatrix(left, right, bottom, top, nearClip, farClip);
     }
     else
     {

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.cpp
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.cpp
@@ -642,10 +642,10 @@ FMatrix FOSVRHMD::GetStereoProjectionMatrix(enum EStereoscopicPass StereoPassTyp
     FScopeLock lock(mutex);
 
     FMatrix ret;
+    double nearClip = GNearClippingPlane;
+    double farClip = 1000000.0;
     if (mCustomPresent)
     {
-        double nearClip = GNearClippingPlane;
-        double farClip = 1000000.0;
         double left, right, bottom, top;
         mCustomPresent->GetProjectionMatrix(
             StereoPassType == eSSP_LEFT_EYE ? 0 : 1,
@@ -656,7 +656,7 @@ FMatrix FOSVRHMD::GetStereoProjectionMatrix(enum EStereoscopicPass StereoPassTyp
     {
         ret = HMDDescription.GetProjectionMatrix(
             StereoPassType == eSSP_LEFT_EYE ? OSVRHMDDescription::LEFT_EYE : OSVRHMDDescription::RIGHT_EYE,
-            DisplayConfig);
+            DisplayConfig, nearClip, farClip);
     }
 
     return ret;

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.cpp
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.cpp
@@ -569,7 +569,7 @@ void FOSVRHMD::CalculateStereoViewOffset(const EStereoscopicPass StereoPassType,
     if (StereoPassType != eSSP_FULL)
     {
         float EyeOffset = (GetInterpupillaryDistance() * WorldToMeters) / 2.0f;
-        const float PassOffset = (StereoPassType == eSSP_LEFT_EYE) ? EyeOffset : -EyeOffset;
+        const float PassOffset = (StereoPassType == eSSP_LEFT_EYE) ? -EyeOffset : EyeOffset;
         ViewLocation += ViewRotation.Quaternion().RotateVector(FVector(0, PassOffset, 0));
 
         const FVector vHMDPosition = DeltaControlOrientation.RotateVector(CurHmdPosition);

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.cpp
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.cpp
@@ -264,10 +264,8 @@ void FOSVRHMD::SetInterpupillaryDistance(float NewInterpupillaryDistance)
 
 void FOSVRHMD::GetFieldOfView(float& OutHFOVInDegrees, float& OutVFOVInDegrees) const
 {
-    FVector2D FOVs = HMDDescription.GetFov(OSVRHMDDescription::LEFT_EYE);
-
-    OutHFOVInDegrees = FOVs.X;
-    OutVFOVInDegrees = FOVs.Y;
+    OutHFOVInDegrees = 0.0f;
+    OutVFOVInDegrees = 0.0f;
 }
 
 void FOSVRHMD::GetCurrentOrientationAndPosition(FQuat& CurrentOrientation, FVector& CurrentPosition)

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.cpp
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.cpp
@@ -642,11 +642,11 @@ FMatrix FOSVRHMD::GetStereoProjectionMatrix(enum EStereoscopicPass StereoPassTyp
     FScopeLock lock(mutex);
 
     FMatrix ret;
-    double nearClip = GNearClippingPlane;
-    double farClip = 1000000.0;
+    float nearClip = GNearClippingPlane;
+    float farClip = TNumericLimits< float >::Max();
     if (mCustomPresent)
     {
-        double left, right, bottom, top;
+        float left, right, bottom, top;
         mCustomPresent->GetProjectionMatrix(
             StereoPassType == eSSP_LEFT_EYE ? 0 : 1,
             left, right, bottom, top, nearClip, farClip);

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.cpp
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.cpp
@@ -569,7 +569,7 @@ void FOSVRHMD::CalculateStereoViewOffset(const EStereoscopicPass StereoPassType,
     if (StereoPassType != eSSP_FULL)
     {
         float EyeOffset = (GetInterpupillaryDistance() * WorldToMeters) / 2.0f;
-        const float PassOffset = (StereoPassType == eSSP_LEFT_EYE) ? -EyeOffset : EyeOffset;
+        const float PassOffset = (StereoPassType == eSSP_LEFT_EYE) ? EyeOffset : -EyeOffset;
         ViewLocation += ViewRotation.Quaternion().RotateVector(FVector(0, PassOffset, 0));
 
         const FVector vHMDPosition = DeltaControlOrientation.RotateVector(CurHmdPosition);

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMDDescription.cpp
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMDDescription.cpp
@@ -16,7 +16,7 @@
 
 #include "OSVRPrivatePCH.h"
 #include "OSVRHMDDescription.h"
-#include <osvr/RenderKit/RenderKitGraphicsTransformsC.h>
+#include <osvr/RenderKit/RenderManagerC.h>
 
 #include "Json.h"
 
@@ -253,7 +253,7 @@ FVector2D OSVRHMDDescription::GetFov(EEye Eye) const
     return FVector2D();
 }
 
-FMatrix OSVRHMDDescription::GetProjectionMatrix(double left, double right, double bottom, double top, double nearClip, double farClip) const
+FMatrix OSVRHMDDescription::GetProjectionMatrix(float left, float right, float bottom, float top, float nearClip, float farClip) const
 {
     // original code
     //float sumRightLeft = static_cast<float>(right + left);
@@ -267,14 +267,17 @@ FMatrix OSVRHMDDescription::GetProjectionMatrix(double left, double right, doubl
     
     // OSVR Render Manager OSVR_Projection_to_D3D with adjustment for unreal (from steamVR plugin)
     OSVR_ProjectionMatrix projection;
-    projection.left = left;
-    projection.right = right;
-    projection.top = top;
-    projection.bottom = bottom;
-    projection.nearClip = nearClip;
-    projection.farClip = farClip;
+    projection.left = static_cast<double>(left);
+    projection.right = static_cast<double>(right);
+    projection.top = static_cast<double>(top);
+    projection.bottom = static_cast<double>(bottom);
+    projection.nearClip = static_cast<double>(nearClip);
+    // @todo Since farClip may be FLT_MAX, round-trip casting to double
+    // and back (via the OSVR_Projection_to_Unreal call) it should
+    // be checked for conversion issues.
+    projection.farClip = static_cast<double>(farClip);
     float p[16];
-    OSVR_Projection_to_D3D(p, projection);
+    OSVR_Projection_to_Unreal(p, projection);
 
     FPlane row1(p[0], p[1], p[2], p[3]);
     FPlane row2(p[4], p[5], p[6], p[7]);
@@ -282,10 +285,10 @@ FMatrix OSVRHMDDescription::GetProjectionMatrix(double left, double right, doubl
     FPlane row4(p[12], p[13], p[14], p[15]);
     FMatrix ret = FMatrix(row1, row2, row3, row4);
 
-    ret.M[3][3] = 0.0f;
-    ret.M[2][3] = 1.0f;
-    ret.M[2][2] = 0.0f;
-    ret.M[3][2] = nearClip;
+    //ret.M[3][3] = 0.0f;
+    //ret.M[2][3] = 1.0f;
+    //ret.M[2][2] = 0.0f;
+    //ret.M[3][2] = nearClip;
 
     // This was suggested by Nick at Epic, but doesn't seem to work? Black screen.
     //ret.M[2][2] = nearClip / (nearClip - farClip);
@@ -298,7 +301,7 @@ FMatrix OSVRHMDDescription::GetProjectionMatrix(double left, double right, doubl
 }
 
 // implemented to match the steamvr projection calculation but with OSVR calculated clipping planes.
-FMatrix OSVRHMDDescription::GetProjectionMatrix(EEye Eye, OSVR_DisplayConfig displayConfig, double nearClip, double farClip) const
+FMatrix OSVRHMDDescription::GetProjectionMatrix(EEye Eye, OSVR_DisplayConfig displayConfig, float nearClip, float farClip) const
 {
     OSVR_EyeCount eye = (Eye == LEFT_EYE ? 0 : 1);
     double left, right, bottom, top;
@@ -309,7 +312,12 @@ FMatrix OSVRHMDDescription::GetProjectionMatrix(EEye Eye, OSVR_DisplayConfig dis
     // The steam plugin inverts the clipping planes here, but that doesn't appear to
     // be necessary for the OSVR calculated planes.
 
-    return GetProjectionMatrix(left, right, bottom, top, nearClip, farClip);
+    return GetProjectionMatrix(
+        static_cast<float>(left),
+        static_cast<float>(right),
+        static_cast<float>(bottom),
+        static_cast<float>(top),
+        nearClip, farClip);
 }
 
 float OSVRHMDDescription::GetInterpupillaryDistance() const

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMDDescription.cpp
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMDDescription.cpp
@@ -261,10 +261,13 @@ FMatrix OSVRHMDDescription::GetProjectionMatrix(double left, double right, doubl
     // ([3][3] = 0, [2][3] = 1, [2][2] = 0, [3][3] = GNearClippingPlane)
 
     // attempts 3-6 (original, attempts 1 and 2, but with inverted bottom/top/left/right, this is what steamVR does)
-    bottom *= -1.0f;
-    top *= -1.0f;
-    right *= -1.0f;
-    left *= -1.0f;
+    //bottom *= -1.0f;
+    //top *= -1.0f;
+    //right *= -1.0f;
+    //left *= -1.0f;
+    //float zNear = GNearClippingPlane;
+    float zNear = 0.1f;
+    float zFar = 10000.0f;
 
     // original code
     //float sumRightLeft = static_cast<float>(right + left);
@@ -275,7 +278,7 @@ FMatrix OSVRHMDDescription::GetProjectionMatrix(double left, double right, doubl
     //FPlane row2(0.0f, 2.0f * inverseTopBottom, 0.0f, 0.0f);
     //FPlane row3((sumRightLeft * inverseRightLeft), (sumTopBottom * inverseTopBottom), 0.0f, 1.0f);
     //FPlane row4(0.0f, 0.0f, zNear, 0.0f);
-
+    
     // attempt 1 (LH D3D off-axis formula)
     //FPlane row1(2.0f * zNear / (right - left), 0, 0, 0);
     //FPlane row2(0, 2.0f * zNear / (top - bottom), 0, 0);
@@ -283,9 +286,6 @@ FMatrix OSVRHMDDescription::GetProjectionMatrix(double left, double right, doubl
     //FPlane row4(0, 0, zNear * zFar / (zNear - zFar), 0);
     
     // attempt 2 (OSVR Render Manager OSVR_Projection_to_D3D with adjustment for unreal (from steamVR plugin)
-    float zNear = 0.1f;
-    float zFar = 100.0f;
-
     OSVR_ProjectionMatrix projection;
     projection.left = left;
     projection.right = right;
@@ -303,7 +303,7 @@ FMatrix OSVRHMDDescription::GetProjectionMatrix(double left, double right, doubl
     FMatrix ret = FMatrix(row1, row2, row3, row4);
 
     ret.M[3][3] = 0.0f;
-    ret.M[2][3] = -1.0f;
+    ret.M[2][3] = 1.0f;
     ret.M[2][2] = 0.0f;
     ret.M[3][2] = GNearClippingPlane;
 

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMDDescription.h
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMDDescription.h
@@ -53,8 +53,8 @@ public:
 	FVector2D GetFov(EEye Eye) const;
     FVector2D GetFov(OSVR_EyeCount Eye) const;
 	FVector GetLocation(EEye Eye) const;
-    FMatrix GetProjectionMatrix(double left, double right, double bottom, double top) const;
-	FMatrix GetProjectionMatrix(EEye Eye, OSVR_DisplayConfig displayConfig) const;
+    FMatrix GetProjectionMatrix(double left, double right, double bottom, double top, double nearClip, double farClip) const;
+	FMatrix GetProjectionMatrix(EEye Eye, OSVR_DisplayConfig displayConfig, double nearClip, double farClip) const;
     bool OSVRViewerFitsUnrealModel(OSVR_DisplayConfig displayConfig);
 
 	// Helper function

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMDDescription.h
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMDDescription.h
@@ -53,8 +53,8 @@ public:
 	FVector2D GetFov(EEye Eye) const;
     FVector2D GetFov(OSVR_EyeCount Eye) const;
 	FVector GetLocation(EEye Eye) const;
-    FMatrix GetProjectionMatrix(double left, double right, double bottom, double top, double nearClip, double farClip) const;
-	FMatrix GetProjectionMatrix(EEye Eye, OSVR_DisplayConfig displayConfig, double nearClip, double farClip) const;
+    FMatrix GetProjectionMatrix(float left, float right, float bottom, float top, float nearClip, float farClip) const;
+	FMatrix GetProjectionMatrix(EEye Eye, OSVR_DisplayConfig displayConfig, float nearClip, float farClip) const;
     bool OSVRViewerFitsUnrealModel(OSVR_DisplayConfig displayConfig);
 
 	// Helper function

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Public/IOSVR.h
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Public/IOSVR.h
@@ -20,7 +20,7 @@
 #include "IHeadMountedDisplayModule.h"
 
 #define OSVR_UNREAL_4_11 1
-#define OSVR_UNREAL_4_12 0
+#define OSVR_UNREAL_4_12 1
 
 class OSVREntryPoint;
 class FOSVRHMD;

--- a/OSVRUnreal/Source/OSVRUnreal/DummyClass.cpp
+++ b/OSVRUnreal/Source/OSVRUnreal/DummyClass.cpp
@@ -1,0 +1,12 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#include "OSVRUnreal.h"
+#include "DummyClass.h"
+
+DummyClass::DummyClass()
+{
+}
+
+DummyClass::~DummyClass()
+{
+}

--- a/OSVRUnreal/Source/OSVRUnreal/DummyClass.h
+++ b/OSVRUnreal/Source/OSVRUnreal/DummyClass.h
@@ -1,0 +1,13 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+/**
+ * 
+ */
+class OSVRUNREAL_API DummyClass
+{
+public:
+	DummyClass();
+	~DummyClass();
+};

--- a/OSVRUnreal/Source/OSVRUnreal/OSVRUnreal.Build.cs
+++ b/OSVRUnreal/Source/OSVRUnreal/OSVRUnreal.Build.cs
@@ -6,21 +6,21 @@ public class OSVRUnreal : ModuleRules
 {
 	public OSVRUnreal(TargetInfo Target)
 	{
-        PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore" });
+		PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore" });
 
-        PrivateDependencyModuleNames.AddRange(new string[] { });
+		PrivateDependencyModuleNames.AddRange(new string[] {  });
 
-        // Uncomment if you are using Slate UI
-        // PrivateDependencyModuleNames.AddRange(new string[] { "Slate", "SlateCore" });
-
-        // Uncomment if you are using online features
-        // PrivateDependencyModuleNames.Add("OnlineSubsystem");
-        // if ((Target.Platform == UnrealTargetPlatform.Win32) || (Target.Platform == UnrealTargetPlatform.Win64))
-        // {
-        //		if (UEBuildConfiguration.bCompileSteamOSS == true)
-        //		{
-        //			DynamicallyLoadedModuleNames.Add("OnlineSubsystemSteam");
-        //		}
-        // }
+		// Uncomment if you are using Slate UI
+		// PrivateDependencyModuleNames.AddRange(new string[] { "Slate", "SlateCore" });
+		
+		// Uncomment if you are using online features
+		// PrivateDependencyModuleNames.Add("OnlineSubsystem");
+		// if ((Target.Platform == UnrealTargetPlatform.Win32) || (Target.Platform == UnrealTargetPlatform.Win64))
+		// {
+		//		if (UEBuildConfiguration.bCompileSteamOSS == true)
+		//		{
+		//			DynamicallyLoadedModuleNames.Add("OnlineSubsystemSteam");
+		//		}
+		// }
 	}
 }

--- a/OSVRUnreal/Source/OSVRUnreal/OSVRUnreal.cpp
+++ b/OSVRUnreal/Source/OSVRUnreal/OSVRUnreal.cpp
@@ -2,4 +2,4 @@
 
 #include "OSVRUnreal.h"
 
-IMPLEMENT_PRIMARY_GAME_MODULE(FDefaultGameModuleImpl, OSVRUnreal, "OSVRUnreal");
+IMPLEMENT_PRIMARY_GAME_MODULE( FDefaultGameModuleImpl, OSVRUnreal, "OSVRUnreal" );

--- a/OSVRUnreal/Source/OSVRUnreal/OSVRUnreal.h
+++ b/OSVRUnreal/Source/OSVRUnreal/OSVRUnreal.h
@@ -3,3 +3,4 @@
 #pragma once
 
 #include "Engine.h"
+


### PR DESCRIPTION
This change updates our RenderManager C API usage to use the new render info collection C API for getting render info atomically. May help address threading issues with ATW turned on at the server, and timing issues outside of that.

Additionally, projection matrix for each eye is now calculated initially by the RenderManager API instead of manually in the plugin code from the clipping planes. 

This PR also updates the default engine target to 4.12, and I regenerated the dummy C++ module from scratch for 4.12 as the old one was having troubles in 4.12.
