### PR TITLE
Switched to using OSVR SDK only, updated build instructions

### DIFF
--- a/ImportFromSDK.cmd
+++ b/ImportFromSDK.cmd
@@ -1,6 +1,7 @@
 @echo off
 
 set PRJ_ROOT=%~dp0
+set XCOPY_ARGS=/f /y
 
 set PLUGIN_ROOT=%~dp0OSVRUnreal\Plugins\OSVR
 IF NOT EXIST "%PLUGIN_ROOT%" goto ERROR_WRONG_PROJ_DIR
@@ -11,33 +12,33 @@ IF NOT EXIST "%DEST_ROOT%" goto ERROR_WRONG_PROJ_DIR
 IF %1.==. (
 	set /p osvr32bit=Type OSVR 32bit SDK root dir:
 ) ELSE (
-	set osvr32bit=%~1
+	set osvr32bit="%~1"
 )
 IF %2.==. (
 	set /p osvr64bit=Type OSVR 64bit SDK root dir:
 ) ELSE (
-	set osvr64bit=%~2
+	set osvr64bit="%~2"
 )
 
 IF %3.==. (
 	set /p osvrAndroid=Type OSVR Android SDK root dir:
 ) ELSE (
-	set osvrAndroid=%~3
+	set osvrAndroid="%~3"
 )
-
-set rm32bit=%rm64bit%
 
 rem Get rid of the old
 RMDIR /S /Q "%DEST_ROOT%\include" > NUL
 RMDIR /S /Q "%DEST_ROOT%\lib" > NUL
 del "%DEST_ROOT%\*.txt" > NUL
 
-call :copy_arch_indep %osvr32bit% %rm32bit% %DEST_ROOT%
+call :copy_arch_indep %osvr32bit% %DEST_ROOT%
 
-call :copy_arch %osvr32bit% %rm32bit% %PLUGIN_ROOT% %DEST_ROOT% 32
-call :copy_arch %osvr64bit% %rm64bit% %PLUGIN_ROOT% %DEST_ROOT% 64
+call :copy_arch %osvr32bit% %PLUGIN_ROOT% %DEST_ROOT% 32
+call :copy_arch %osvr64bit% %PLUGIN_ROOT% %DEST_ROOT% 64
 call :copy_android %osvrAndroid% %PLUGIN_ROOT% %DEST_ROOT%
 
+echo,
+echo Done
 echo Note: The 32-bit target is not yet supported. Please use the 64-bit target only for now.
 
 goto :eof
@@ -45,19 +46,24 @@ goto :eof
 
 :copy_arch_indep
 rem Architecture-independent files
+echo,
+echo Architecture-independent files
+echo,
 setlocal
 set SRC=%1
-set SRC_RM=%src%
-set DEST_ROOT=%3
-xcopy %SRC%\include\osvr\ClientKit "%DEST_ROOT%\include\osvr\ClientKit" /S /I /y
-xcopy %SRC%\include\osvr\Util "%DEST_ROOT%\include\osvr\Util" /S /I /y
-xcopy %SRC%\include\osvr\Client "%DEST_ROOT%\include\osvr\Client" /S /I /y
-xcopy %SRC%\include\osvr\Common "%DEST_ROOT%\include\osvr\Common" /S /I /y
-xcopy %SRC_RM%\include\osvr\RenderKit "%DEST_ROOT%\include\osvr\RenderKit" /S /I /y
+set DEST_ROOT=%2
+xcopy %SRC%\include\osvr\ClientKit "%DEST_ROOT%\include\osvr\ClientKit" /S /I %XCOPY_ARGS%
+xcopy %SRC%\include\osvr\Util "%DEST_ROOT%\include\osvr\Util" /S /I %XCOPY_ARGS%
+xcopy %SRC%\include\osvr\Client "%DEST_ROOT%\include\osvr\Client" /S /I %XCOPY_ARGS%
+xcopy %SRC%\include\osvr\Common "%DEST_ROOT%\include\osvr\Common" /S /I %XCOPY_ARGS%
+xcopy %SRC%\include\osvr\RenderKit "%DEST_ROOT%\include\osvr\RenderKit" /S /I %XCOPY_ARGS%
 endlocal
 goto :eof
 
 :copy_android
+echo,
+echo Android files
+echo,
 
 set SRC=%1
 set PLUGIN_ROOT=%2
@@ -65,8 +71,8 @@ set DEST_ROOT=%3
 set SRC_LIB=%SRC%\NDK\osvr\builds\armeabi-v7a\lib
 
 for %%F in (%SRC_LIB%\libcrystax.so,%SRC_LIB%\libfunctionality.so,%SRC_LIB%\libgnustl_shared.so,%SRC_LIB%\libjsoncpp.so,%SRC_LIB%\libosvrAnalysisPluginKit.so,%SRC_LIB%\libosvrClient.so,%SRC_LIB%\libosvrClientKit.so,%SRC_LIB%\libosvrCommon.so,%SRC_LIB%\libosvrConnection.so,%SRC_LIB%\libosvrJointClientKit.so,%SRC_LIB%\libosvrPluginHost.so,%SRC_LIB%\libosvrServer.so,%SRC_LIB%\libosvrUtil.so,%SRC_LIB%\libosvrVRPNServer.so) do (
-  echo xcopy %%F "%DEST_ROOT%\bin\Android\armeabi-v7a\" /Y
-  xcopy %%F "%DEST_ROOT%\bin\Android\armeabi-v7a\" /Y
+  rem echo xcopy %%F "%DEST_ROOT%\bin\Android\armeabi-v7a\" %XCOPY_ARGS%
+  xcopy %%F "%DEST_ROOT%\bin\Android\armeabi-v7a\" %XCOPY_ARGS%
 )
 
 endlocal
@@ -76,26 +82,31 @@ goto :eof
 rem Architecture-dependent files
 setlocal
 set SRC=%1
-set SRC_RM=%2
-set PLUGIN_ROOT=%3
-set DEST_ROOT=%4
-set BITS=%5
+set PLUGIN_ROOT=%2
+set DEST_ROOT=%3
+set BITS=%4
+echo,
+echo Architecture-dependent files %BITS%
+echo,
 
-copy "%SRC%\osvr-ver.txt" "%DEST_ROOT%\Win%BITS%osvr-ver.txt" /y
+echo.> "%DEST_ROOT%\Win%BITS%osvr-ver.txt"
+rem echo xcopy %SRC%\bin\osvr-ver.txt "%DEST_ROOT%\Win%BITS%osvr-ver.txt" /i %XCOPY_ARGS% 
+xcopy %SRC%\bin\osvr-ver.txt "%DEST_ROOT%\Win%BITS%osvr-ver.txt" %XCOPY_ARGS% 
 
 rem One copy to the bin directory, for use in deployment.
-call :copy_dll %SRC% %SRC_RM% %DEST_ROOT%\bin %BITS%
+call :copy_dll %SRC% %DEST_ROOT%\bin %BITS%
 
 rem One copy to the plugin Binaries directory, for editor support.
-call :copy_dll %SRC% %SRC_RM% %PLUGIN_ROOT%\Binaries %BITS%
+call :copy_dll %SRC% %PLUGIN_ROOT%\Binaries %BITS%
 
 rem libs
 for %%F in (%SRC%\lib\osvrClientKit.lib) do (
-  xcopy %%F "%DEST_ROOT%\lib\Win%BITS%\" /Y
+  xcopy %%F "%DEST_ROOT%\lib\Win%BITS%\" %XCOPY_ARGS%
 )
 
-for %%F in (%SRC_RM%\lib\osvrRenderManager.lib) do (
-  xcopy %%F "%DEST_ROOT%\lib\Win%BITS%\" /Y
+for %%F in (%SRC%\lib\osvrRenderManager.lib) do (
+  rem echo xcopy %%F "%DEST_ROOT%\lib\Win%BITS%\" %XCOPY_ARGS%
+  xcopy %%F "%DEST_ROOT%\lib\Win%BITS%\" %XCOPY_ARGS%
 )
 
 endlocal
@@ -105,15 +116,14 @@ goto :eof
 rem Copy DLL files
 setlocal
 set SRC=%1
-set SRC_RM=%2
-set DEST=%3
-set BITS=%4
+set DEST=%2
+set BITS=%3
 for %%F in (%SRC%\bin\osvrClientKit.dll,%SRC%\bin\osvrClient.dll,%SRC%\bin\osvrUtil.dll,%SRC%\bin\osvrCommon.dll) do (
-  xcopy %%F "%DEST%\Win%BITS%\" /Y
+  xcopy %%F "%DEST%\Win%BITS%\" %XCOPY_ARGS%
 )
-for %%F in (%SRC_RM%\bin\osvrRenderManager.dll,%SRC_RM%\bin\d3dcompiler_47.dll,%SRC_RM%\bin\glew32.dll,%SRC_RM%\bin\SDL2.dll) do (
-  echo xcopy %%F "%DEST%\Win%BITS%\" /Y
-  xcopy %%F "%DEST%\Win%BITS%\" /Y
+for %%F in (%SRC%\bin\osvrRenderManager.dll,%SRC%\bin\d3dcompiler_47.dll,%SRC%\bin\glew32.dll,%SRC%\bin\SDL2.dll) do (
+  rem echo xcopy %%F "%DEST%\Win%BITS%\" %XCOPY_ARGS%
+  xcopy %%F "%DEST%\Win%BITS%\" %XCOPY_ARGS%
 )
 endlocal
 goto :eof

--- a/README.md
+++ b/README.md
@@ -33,11 +33,12 @@ release of the built-in plugin. You will need to disable the built-in plugin fir
 if you previously enabled it.
 
 ### Dependencies
-You need OSVR-Core (32-bit and 64-bit) and Render Manager. Prebuilt binaries are available here:
- > http://osvr.github.io/using/
 
-You will also need the OSVR-Android binaries. Prebuild binaries are available here:
- > http://resource.osvr.com/public_download/artifacts/osvr-android-ndk/osvr-android-ndk.tar.bz2
+ 1. You need OSVR SDK (32-bit and 64-bit).
+  * Prebuilt binaries are available here: http://osvr.github.io/using/
+  * NOTE: Installing the 64-bit version currently uninstalls the 32-bit version.  A workaround is to install the 32-bit version, copy the SDK directory to a temp dir, install the 64-bit version, then copy the temp 32-bit SDK directory back into place.
+ 2. You will also need the OSVR-Android binaries.
+  * Prebuild binaries are available here: http://resource.osvr.com/public_download/artifacts/osvr-android-ndk/osvr-android-ndk.tar.bz2
 
 ### Integrating the plugin from source with an existing project
 The current recommended way to integrate the OSVR Unreal plugin with an existing project is directly from source.
@@ -45,17 +46,14 @@ The current recommended way to integrate the OSVR Unreal plugin with an existing
  1. Clone the OSVR-Unreal source code, or download a zip from github.
  2. Run the ImportFromSDK.cmd script and specify the SDK paths as it prompts you.   
   * NOTE: It's easiest to drag the folders to the console window when it prompts you for SDK paths, as this will automatically wrap the paths in quotes as needed. If you enter them in manually, please use quotes around any paths with spaces in them.
- 3. Check that the OSVR-Core and Render Manager binaries have been copied to the correct place in OSVRUnreal/Plugins/OSVR/Source/OSVRClientKit/bin, include, and lib.
- 4. You do not need to build OSVR-Unreal's project. Instead, copy the OSVRUnrea/Source and OSVRUnreal/Plugins directories to your existing project's top-level directory.
- 5. Temporarily rename the Plugins folder something else, like Plugins_. This will allow you to open the project in the editor without first building the plugin. Without this step, the editor will complain about the OSVR module being missing.
- 6. Open the existing project in the Unreal editor.
- 7. Rename the Plugins_ folder back to Plugins.
- 8. Select Generate Visual Studio Project, or Refresh Visual Studio Project, from the File menu.
-  * NOTE: if your project is a pure blueprint project, you may need to add a dummy C++ game module to your project to get Unreal to generate a Visual Studio project for you. Otherwise it may complain about there not being any code to compile (having local plugins isn't enough).
- 9. Open the generated or refreshed Visual Studio project and rebuild using the Development Editor build configuration.  The file will be in the project's top-level directory.  Make sure to select Win64 as the target.
- 10. Confirm that the OSVR plugin binaries were copied correctly to YourProject/Binaries/Win64 and YourProject/Binaries/Android/armeabi-v7a. If not, you will need to copy binaries from YourProject/Plugins/OSVR/Binaries (or YourProject/Plugins/OSVR/Source/OSVRClientKit/bin if Binaries is not available) to YourProject/Binaries.
-
- > Note: There is only a 64-bit installer available for RenderManager, so for now only the 64-bit Unreal targets are supported at this time.
+  * Example command line: ```ImportFromSDK.cmd "C:\Program Files (x86)\OSVR\SDK" "C:\Program Files\OSVR\SDK" D:\3rdParty\osvr-android-ndk```
+ 3. Check that the OSVR binaries have been copied to the correct place in OSVRUnreal/Plugins/OSVR/Source/OSVRClientKit/bin, include, and lib.
+ 4. You do not need to build OSVR-Unreal's project. Instead, copy the OSVRUnreal/Plugins/OSVR directory to your existing project's Plugins directory.
+ 5. You can either load your .uproject file and let UE4Editor automatically handle any Plugin rebuilding needed, or you can do it manually following the next steps.
+ 5. Select Generate Visual Studio Project, or Refresh Visual Studio Project, from the File menu of your .uproject file
+  * NOTE: if your project is a pure Blueprint project, you may need to add a dummy C++ game module to your project to get Unreal to generate a Visual Studio project for you. Otherwise it may complain about there not being any code to compile (having local plugins isn't enough).
+ 6. Open the generated or refreshed Visual Studio project and rebuild using the Development Editor build configuration.  The file will be in the project's top-level directory.  Make sure to select Win64 as the target.
+ 7. Confirm that the OSVR plugin binaries were copied correctly to YourProject/Binaries/Win64 and YourProject/Binaries/Android/armeabi-v7a. If not, you will need to copy binaries from YourProject/Plugins/OSVR/Binaries (or YourProject/Plugins/OSVR/Source/OSVRClientKit/bin if Binaries is not available) to YourProject/Binaries.
 
  > Note: Android support is currently preliminary/alpha-quality. It is not yet ready for production. If you still want to build for Android without OSVR support enabled, remove Android from the WhiteListPlatforms of both OSVR and OSVRInput modules in /OSVRUnreal/Plugins/OSVR/OSVR.uplugin.
 


### PR DESCRIPTION
This change switches ImportFromSDK.cmd to only requiring OSVR SDK and the OSVR Android SDK, has some general cleanup in the script and output, and updates build instructions to be more clear and remove unneeded steps.

In addition, I took @russell-taylor 's pull request (guessing he was making similar changes simultaneously) https://github.com/OSVR/OSVR-Unreal/pull/76 and merged my changes with it, making a combined pull with both our improvements (since they had conflicts due to us both making similar changes).
