### PR TITLE
Avoid infinite hang BuildCookRun commandlet due to OSVR server connec…

### DIFF
--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVREntryPoint.cpp
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVREntryPoint.cpp
@@ -29,6 +29,12 @@ DEFINE_LOG_CATEGORY(OSVREntryPointLog);
 
 OSVREntryPoint::OSVREntryPoint()
 {
+    // avoid BuildCookRun hangs
+    if (IsRunningCommandlet() || IsRunningDedicatedServer())
+    {
+        return;
+    }
+
     osvrClientAttemptServerAutoStart();
 
     osvrClientContext = osvrClientInit("com.osvr.unreal.plugin");

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVREntryPoint.cpp
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVREntryPoint.cpp
@@ -32,6 +32,7 @@ OSVREntryPoint::OSVREntryPoint()
     // avoid BuildCookRun hangs
     if (IsRunningCommandlet() || IsRunningDedicatedServer())
     {
+        UE_LOG(OSVREntryPointLog, Display, TEXT("OSVREntryPoint::OSVREntryPoint(): running as commandlet or dedicated server - skipping client context startup."));
         return;
     }
 
@@ -77,7 +78,11 @@ OSVREntryPoint::~OSVREntryPoint()
     InterfaceCollection = nullptr;
 #endif
 
-    osvrClientShutdown(osvrClientContext);
+    if (osvrClientContext)
+    {
+       osvrClientShutdown(osvrClientContext);
+    }
+
     osvrClientReleaseAutoStartedServer();
 }
 


### PR DESCRIPTION
…t failure

For #81 

Didn't include switching plugin module Types to "RuntimeNoCommandlet"
