### PR TITLE
IOSVR::Get cleanup

### DIFF
--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVR.cpp
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVR.cpp
@@ -29,7 +29,7 @@ class FOSVR : public IOSVR
 private:
     TSharedPtr<FOSVRHMD, ESPMode::ThreadSafe> hmd;
     FCriticalSection mModuleMutex;
-    TSharedPtr< class OSVREntryPoint > EntryPoint;
+    TSharedPtr<class OSVREntryPoint, ESPMode::ThreadSafe> EntryPoint;
     bool bModulesLoaded = false;
 public:
     /** IModuleInterface implementation */
@@ -37,7 +37,7 @@ public:
     virtual void ShutdownModule() override;
 
     /** IHeadMountedDisplayModule implementation */
-    virtual TSharedPtr< class IHeadMountedDisplay, ESPMode::ThreadSafe > CreateHeadMountedDisplay() override;
+    virtual TSharedPtr<class IHeadMountedDisplay, ESPMode::ThreadSafe> CreateHeadMountedDisplay() override;
 #if OSVR_UNREAL_4_12
     virtual bool IsHMDConnected() override;
 #endif
@@ -45,16 +45,16 @@ public:
     // Pre-init the HMD module (optional).
     //virtual void PreInit() override;
 
-    virtual OSVREntryPoint* GetEntryPoint() override;
+    virtual TSharedPtr<OSVREntryPoint, ESPMode::ThreadSafe> GetEntryPoint() override;
     virtual TSharedPtr<FOSVRHMD, ESPMode::ThreadSafe> GetHMD() override;
     virtual void LoadOSVRClientKitModule() override;
 };
 
 IMPLEMENT_MODULE(FOSVR, OSVR)
 
-OSVREntryPoint* FOSVR::GetEntryPoint()
+TSharedPtr<class OSVREntryPoint, ESPMode::ThreadSafe> FOSVR::GetEntryPoint()
 {
-    return EntryPoint.Get();
+    return EntryPoint;
 }
 
 TSharedPtr<FOSVRHMD, ESPMode::ThreadSafe> FOSVR::GetHMD()
@@ -129,7 +129,7 @@ TSharedPtr< class IHeadMountedDisplay, ESPMode::ThreadSafe > FOSVR::CreateHeadMo
 {
     if (EntryPoint->IsOSVRConnected())
     {
-        TSharedPtr< FOSVRHMD, ESPMode::ThreadSafe > OSVRHMD(new FOSVRHMD());
+        TSharedPtr< FOSVRHMD, ESPMode::ThreadSafe > OSVRHMD(new FOSVRHMD(EntryPoint));
         if (OSVRHMD->IsInitialized() && OSVRHMD->IsHMDConnected())
         {
             hmd = OSVRHMD;

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.h
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.h
@@ -157,7 +157,7 @@ public:
 
 public:
     /** Constructor */
-    FOSVRHMD();
+    FOSVRHMD(TSharedPtr<class OSVREntryPoint, ESPMode::ThreadSafe> entryPoint);
 
     /** Destructor */
     virtual ~FOSVRHMD();
@@ -170,7 +170,9 @@ private:
     void UpdateHeadPose();
     void StartCustomPresent();
     void StopCustomPresent();
+    void GetRenderTargetSize_GameThread(float windowWidth, float windowHeight, float &width, float &height);
 
+    TSharedPtr<class OSVREntryPoint, ESPMode::ThreadSafe> mOSVREntryPoint;
     IRendererModule* RendererModule;
 
     /** Player's orientation tracking */

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Public/IOSVR.h
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Public/IOSVR.h
@@ -60,7 +60,7 @@ public:
     }
 
     virtual void LoadOSVRClientKitModule() = 0;
-    virtual OSVREntryPoint* GetEntryPoint() = 0;
+    virtual TSharedPtr<class OSVREntryPoint, ESPMode::ThreadSafe> GetEntryPoint() = 0;
     virtual TSharedPtr<FOSVRHMD, ESPMode::ThreadSafe> GetHMD() = 0;
 };
 

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVRInput/Private/OSVRInput.cpp
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVRInput/Private/OSVRInput.cpp
@@ -38,13 +38,15 @@ IMPLEMENT_MODULE(FOSVRInput, OSVRInput)
 
 TSharedPtr< class IInputDevice > FOSVRInput::CreateInputDevice(const TSharedRef< FGenericApplicationMessageHandler >& InMessageHandler)
 {
-    auto entryPoint = IOSVR::Get().GetEntryPoint();
+    auto& osvr = IOSVR::Get();
+    auto entryPoint = osvr.GetEntryPoint();
+    auto osvrHMD = osvr.GetHMD();
     FScopeLock lock(entryPoint->GetClientContextMutex());
     if (entryPoint->IsOSVRConnected())
     {
         FOSVRInputDevice::RegisterNewKeys();
 
-        InputDevice = MakeShareable(new FOSVRInputDevice(InMessageHandler));
+        InputDevice = MakeShareable(new FOSVRInputDevice(InMessageHandler, entryPoint, osvrHMD));
         return InputDevice;
     }
     return nullptr;

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVRInput/Private/OSVRInputDevice.cpp
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVRInput/Private/OSVRInputDevice.cpp
@@ -111,14 +111,16 @@ void FOSVRInputDevice::RegisterNewKeys()
 {
 }
 
-FOSVRInputDevice::FOSVRInputDevice(const TSharedRef< FGenericApplicationMessageHandler >& InMessageHandler)
-    : MessageHandler(InMessageHandler)
+FOSVRInputDevice::FOSVRInputDevice(
+    const TSharedRef< FGenericApplicationMessageHandler >& InMessageHandler,
+    TSharedPtr<OSVREntryPoint, ESPMode::ThreadSafe> osvrEntryPoint,
+    TSharedPtr<FOSVRHMD, ESPMode::ThreadSafe> osvrHMD) :
+    mOSVREntryPoint(osvrEntryPoint), mOSVRHMD(osvrHMD), MessageHandler(InMessageHandler)
 {
     // make sure OSVR module is loaded.
-    auto entryPoint = IOSVR::Get().GetEntryPoint();
-    contextMutex = entryPoint->GetClientContextMutex();
+    contextMutex = mOSVREntryPoint->GetClientContextMutex();
     FScopeLock lock(contextMutex);
-    context = entryPoint->GetClientContext();
+    context = mOSVREntryPoint->GetClientContext();
 
     bContextValid = context && osvrClientCheckStatus(context) == OSVR_RETURN_SUCCESS;
 
@@ -309,7 +311,7 @@ bool FOSVRInputDevice::GetControllerOrientationAndPosition(const int32 Controlle
             OSVR_TimeValue tvalue;
             if (osvrGetPoseState(iface, &tvalue, &state) == OSVR_RETURN_SUCCESS)
             {
-                float worldToMetersScale = IOSVR::Get().GetHMD()->GetWorldToMetersScale();
+                float worldToMetersScale = mOSVRHMD->GetWorldToMetersScale();
                 OutPosition = OSVR2FVector(state.translation, worldToMetersScale);
                 OutOrientation = OSVR2FQuat(state.rotation).Rotator();
                 bRet = true;

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVRInput/Private/OSVRInputDevice.h
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVRInput/Private/OSVRInputDevice.h
@@ -40,7 +40,8 @@ class OSVRButton;
 class FOSVRInputDevice : public IInputDevice, public IMotionController
 {
 public:
-    FOSVRInputDevice(const TSharedRef< FGenericApplicationMessageHandler >& MessageHandler);
+    FOSVRInputDevice(const TSharedRef< FGenericApplicationMessageHandler >& MessageHandler,
+        TSharedPtr<OSVREntryPoint, ESPMode::ThreadSafe> osvrEntryPoint, TSharedPtr<FOSVRHMD, ESPMode::ThreadSafe> osvrHMD);
     virtual ~FOSVRInputDevice();
     static void RegisterNewKeys();
 
@@ -80,6 +81,8 @@ public:
     void EventReport(const FKey& Key, const FVector& Translation, const FQuat& Orientation);
 
 private:
+    TSharedPtr<OSVREntryPoint, ESPMode::ThreadSafe> mOSVREntryPoint;
+    TSharedPtr<FOSVRHMD, ESPMode::ThreadSafe> mOSVRHMD;
     TMap<FString, OSVR_ClientInterface> interfaces;
     TArray<TSharedPtr<OSVRButton> > osvrButtons;
     OSVR_ClientContext context;


### PR DESCRIPTION
Use constructor injection instead of `IOSVR::Get` calls except for the top level `OSVRInput` module code. Removed all `IOSVR::Get` calls from the `OSVR` module itself.

May help address the following issues (Hard to say, can't reliably reproduce these):
https://github.com/OSVR/OSVR-Unreal/issues/92
https://github.com/OSVR/OSVR-Unreal/issues/87
https://github.com/OSVR/OSVR-Unreal/issues/86
