### PR TITLE
Added longer timeout to OSVREntryPoint's context creation.

### DIFF
--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVREntryPoint.cpp
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVREntryPoint.cpp
@@ -44,7 +44,7 @@ OSVREntryPoint::OSVREntryPoint()
         bool bClientContextOK = false;
         bool bFailure = false;
         auto begin = FDateTime::Now().GetSecond();
-        auto end = begin + 3;
+        auto end = begin + 10;
         while (FDateTime::Now().GetSecond() < end && !bClientContextOK && !bFailure)
         {
             bClientContextOK = osvrClientCheckStatus(osvrClientContext) == OSVR_RETURN_SUCCESS;

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVREntryPoint.cpp
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVREntryPoint.cpp
@@ -53,7 +53,7 @@ OSVREntryPoint::OSVREntryPoint()
                 bFailure = osvrClientUpdate(osvrClientContext) == OSVR_RETURN_FAILURE;
                 if (bFailure)
                 {
-                    UE_LOG(OSVREntryPointLog, Warning, TEXT("osvrClientUpdate failed during startup. Treating this as \"HMD not connected\""));
+                    UE_LOG(OSVREntryPointLog, Display, TEXT("osvrClientUpdate failed during startup. Treating this as if the HMD is not connected.));
                     break;
                 }
                 FPlatformProcess::Sleep(0.2f);
@@ -61,7 +61,7 @@ OSVREntryPoint::OSVREntryPoint()
         }
         if (!bClientContextOK)
         {
-            UE_LOG(OSVREntryPointLog, Warning, TEXT("OSVR client context did not initialize correctly. Most likely the server isn't running. Treating this as if the HMD is not connected."));
+            UE_LOG(OSVREntryPointLog, Display, TEXT("OSVR client context could not connect. Most likely the server isn't running. Treating this as if the HMD is not connected."));
         }
     }
 


### PR DESCRIPTION
Possible mitigation to https://github.com/OSVR/OSVR-Unreal/issues/89 although I can't eliminate the possibility without taking out the timeout functionality, which would cause a hang if no SDK is installed.
