### PR TITLE
Renderinfo fix

### DIFF
--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRCustomPresent.h
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRCustomPresent.h
@@ -105,6 +105,11 @@ public:
         return bInitialized;
     }
 
+    virtual bool IsDisplayOpen()
+    {
+        return bDisplayOpen;
+    }
+
     virtual bool LazySetSrcTexture(FTexture2DRHIParamRef srcTexture)
     {
         FScopeLock lock(&mOSVRMutex);
@@ -145,6 +150,10 @@ public:
 
     virtual void GetProjectionMatrix(OSVR_RenderInfoCount eye, float &left, float &right, float &bottom, float &top, float nearClip, float farClip)
     {
+        check(IsInitialized());
+        check(IsDisplayOpen());
+        FScopeLock lock(&mOSVRMutex);
+
         OSVR_ReturnCode rc;
         rc = osvrRenderManagerGetDefaultRenderParams(&mRenderParams);
         check(rc == OSVR_RETURN_SUCCESS);
@@ -224,6 +233,7 @@ protected:
     template<class TGraphicsDevice>
     TGraphicsDevice* GetGraphicsDevice()
     {
+        check(IsInRenderingThread());
         auto ret = RHIGetNativeDevice();
         return reinterpret_cast<TGraphicsDevice*>(ret);
     }

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRCustomPresent.h
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRCustomPresent.h
@@ -140,12 +140,17 @@ public:
     virtual void UpdateCachedDisplayRenderInfoCollection()
     {
         FScopeLock lock(&mOSVRMutex);
-        OSVR_ReturnCode rc;
-        if (mCachedDisplayRenderInfoCollection) {
-            rc = osvrRenderManagerReleaseRenderInfoCollection(mCachedDisplayRenderInfoCollection);
-            check(rc == OSVR_RETURN_SUCCESS);
+        UpdateCachedDisplayRenderInfoCollectionImpl();
+    }
+
+    virtual OSVR_Pose3 GetHeadPoseFromCachedDisplayRenderInfoCollection(bool updateCache = true)
+    {
+        FScopeLock lock(&mOSVRMutex);
+        if (updateCache)
+        {
+            UpdateCachedDisplayRenderInfoCollectionImpl();
         }
-        rc = osvrRenderManagerGetRenderInfoCollection(mRenderManager, mRenderParams, &mCachedDisplayRenderInfoCollection);
+        return GetHeadPoseFromCachedDisplayRenderInfoCollectionImpl();
     }
 
     virtual void GetProjectionMatrix(OSVR_RenderInfoCount eye, float &left, float &right, float &bottom, float &top, float nearClip, float farClip)
@@ -229,7 +234,20 @@ protected:
     virtual bool InitializeImpl() = 0;
     virtual bool LazyOpenDisplayImpl() = 0;
     virtual bool LazySetSrcTextureImpl(FTexture2DRHIParamRef srcTexture) = 0;
-    
+    virtual OSVR_Pose3 GetHeadPoseFromCachedDisplayRenderInfoCollectionImpl() = 0;
+
+    virtual void UpdateCachedDisplayRenderInfoCollectionImpl()
+    {
+        OSVR_ReturnCode rc;
+        if (mCachedDisplayRenderInfoCollection) {
+            rc = osvrRenderManagerReleaseRenderInfoCollection(mCachedDisplayRenderInfoCollection);
+            check(rc == OSVR_RETURN_SUCCESS);
+        }
+        rc = osvrRenderManagerGetRenderInfoCollection(mRenderManager, mRenderParams, &mCachedDisplayRenderInfoCollection);
+        check(rc == OSVR_RETURN_SUCCESS);
+    }
+
+
     template<class TGraphicsDevice>
     TGraphicsDevice* GetGraphicsDevice()
     {

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRCustomPresentD3D11.h
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRCustomPresentD3D11.h
@@ -124,7 +124,6 @@ public:
             outShaderResourceTexture = targetableTexture->GetTexture2D();
             mRenderTexture = targetableTexture;
             bRenderBuffersNeedToUpdate = true;
-            UpdateRenderBuffers();
             return true;
         }
         return false;
@@ -386,12 +385,6 @@ protected:
             }
 
             // We need to register these new buffers.
-            // @todo RegisterRenderBuffers doesn't do anything other than set a flag and crash
-            // if you pass it a non-empty vector here. Passing it a dummy array for now.
-            if (IsInRenderingThread() && IsInitialized() && !bDisplayOpen)
-            {
-                bDisplayOpen = LazyOpenDisplayImpl();
-            }
 
             {
                 OSVR_RenderManagerRegisterBufferState state;

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.cpp
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.cpp
@@ -245,6 +245,8 @@ void FOSVRHMD::UpdateHeadPose(FQuat& lastHmdOrientation, FVector& lastHmdPositio
         lastHmdOrientation = hmdOrientation = FQuat::Identity;
         lastHmdPosition = hmdPosition = FVector(0.0f, 0.0f, 0.0f);
     }
+
+    mCustomPresent->UpdateCachedDisplayRenderInfoCollection();
 }
 
 bool FOSVRHMD::DoesSupportPositionalTracking() const

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.cpp
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.cpp
@@ -220,16 +220,16 @@ void FOSVRHMD::UpdateHeadPose()
 
 void FOSVRHMD::UpdateHeadPose(FQuat& lastHmdOrientation, FVector& lastHmdPosition, FQuat& hmdOrientation, FVector& hmdPosition)
 {
-    OSVR_Pose3 pose;
-    OSVR_ReturnCode returnCode;
+    //OSVR_ReturnCode returnCode;
     FScopeLock lock(mOSVREntryPoint->GetClientContextMutex());
+    OSVR_Pose3 pose = mCustomPresent->GetHeadPoseFromCachedDisplayRenderInfoCollection(true);
     auto clientContext = mOSVREntryPoint->GetClientContext();
 
-    returnCode = osvrClientUpdate(clientContext);
-    check(returnCode == OSVR_RETURN_SUCCESS);
+    //returnCode = osvrClientUpdate(clientContext);
+    //check(returnCode == OSVR_RETURN_SUCCESS);
 
-    returnCode = osvrClientGetViewerPose(DisplayConfig, 0, &pose);
-    if (returnCode == OSVR_RETURN_SUCCESS)
+    //returnCode = osvrClientGetViewerPose(DisplayConfig, 0, &pose);
+    //if (returnCode == OSVR_RETURN_SUCCESS)
     {
         LastHmdOrientation = CurHmdOrientation;
         LastHmdPosition = CurHmdPosition;
@@ -240,13 +240,13 @@ void FOSVRHMD::UpdateHeadPose(FQuat& lastHmdOrientation, FVector& lastHmdPositio
         hmdOrientation = CurHmdOrientation;
         hmdPosition = CurHmdPosition;
     }
-    else
-    {
-        lastHmdOrientation = hmdOrientation = FQuat::Identity;
-        lastHmdPosition = hmdPosition = FVector(0.0f, 0.0f, 0.0f);
-    }
+    //else
+    //{
+    //    lastHmdOrientation = hmdOrientation = FQuat::Identity;
+    //    lastHmdPosition = hmdPosition = FVector(0.0f, 0.0f, 0.0f);
+    //}
 
-    mCustomPresent->UpdateCachedDisplayRenderInfoCollection();
+    
 }
 
 bool FOSVRHMD::DoesSupportPositionalTracking() const

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.h
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.h
@@ -165,7 +165,7 @@ private:
     void UpdateHeadPose();
     void StartCustomPresent();
     void StopCustomPresent();
-    void GetRenderTargetSize_GameThread(float windowWidth, float windowHeight, float &width, float &height);
+    void GetRenderTargetSize_GameThread(float windowWidth, float windowHeight, float &width, float &height) const;
     float GetScreenScale() const;
 
     TSharedPtr<class OSVREntryPoint, ESPMode::ThreadSafe> mOSVREntryPoint;


### PR DESCRIPTION
This PR fixes issues with ATW and/or prediction turned on in the server config. There are still known issues with this code, namely not passing back the exact render info that was used to render the scene, and not double buffering the presented render targets, but those will be addressed in a future issue.
