### PR TITLE
Linux support

### DIFF
--- a/OSVRUnreal/Plugins/OSVR/OSVR.uplugin
+++ b/OSVRUnreal/Plugins/OSVR/OSVR.uplugin
@@ -17,13 +17,13 @@
       "Name": "OSVR",
       "Type": "Runtime",
       "LoadingPhase": "PreDefault",
-      "WhitelistPlatforms": [ "Win32", "Win64" ]
+      "WhitelistPlatforms": [ "Win32", "Win64", "Linux"]
     },
     {
       "Name": "OSVRInput",
       "Type": "Runtime",
       "LoadingPhase": "PreDefault",
-      "WhitelistPlatforms": [ "Win32", "Win64" ]
+      "WhitelistPlatforms": [ "Win32", "Win64", "Linux" ]
     }
 	]
 }

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/OSVR.Build.cs
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/OSVR.Build.cs
@@ -15,8 +15,9 @@ public class OSVR : ModuleRules
             new string[] {
 				"OSVR/Private",
                 openglDrvPrivatePath,
-                openglPath
+                openglPath,
 				// ... add other private include paths required here ...
+                "/media/u/build/OSVR/install/include/"
 			}
             );
 

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/OSVR.Build.cs
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/OSVR.Build.cs
@@ -8,39 +8,39 @@ public class OSVR : ModuleRules
         PrivateIncludePathModuleNames.Add("TargetPlatform");
 
         var EngineDir = Path.GetFullPath(BuildConfiguration.RelativeEnginePath);
-        var openglDrvPrivatePath = Path.Combine(EngineDir, @"Source\Runtime\OpenGLDrv\Private");
-        var openglPath = Path.Combine(EngineDir, @"Source\ThirdParty\OpenGL");
+        var openglDrvPrivatePath = Path.Combine(EngineDir, @"Source/Runtime/OpenGLDrv/Private");
+        var openglPath = Path.Combine(EngineDir, @"Source/ThirdParty/OpenGL");
 
         PrivateIncludePaths.AddRange(
             new string[] {
-				"OSVR/Private",
+                "OSVR/Private",
                 openglDrvPrivatePath,
                 openglPath,
-				// ... add other private include paths required here ...
+                // ... add other private include paths required here ...
                 "/media/u/build/OSVR/install/include/"
-			}
-            );
+            });
 
         PrivateDependencyModuleNames.AddRange(
             new string[]
-			{
-				"OSVRClientKit",
-                "Core",
-				"CoreUObject",      // Provides Actors and Structs
-				"Engine",           // Used by Actor
-				"Slate",            // Used by InputDevice to fire bespoke FKey events
-				"InputCore",        // Provides LOCTEXT and other Input features
-				"InputDevice",      // Provides IInputInterface
-				"RHI",
-				"RenderCore",
-				"Renderer",
-				"ShaderCore",
-				"HeadMountedDisplay",
-				"Json",
-                "OpenGLDrv"
-				// ... add private dependencies that you statically link with here ...
-			}
-            );
+                {
+                    "OSVRClientKit",
+                    "Core",
+                    "CoreUObject",      // Provides Actors and Structs
+                    "Engine",           // Used by Actor
+                    "Slate",            // Used by InputDevice to fire bespoke FKey events
+                    "InputCore",        // Provides LOCTEXT and other Input features
+                    "InputDevice",      // Provides IInputInterface
+                    "RHI",
+                    "RenderCore",
+                    "Renderer",
+                    "ShaderCore",
+                    "HeadMountedDisplay",
+                    "Json",
+                    "OpenGLDrv",
+                    "SDL2"
+                    // ... add private dependencies that you statically link with here ...
+                });
+        
         if(UEBuildConfiguration.bBuildEditor == true)
         {
             PrivateDependencyModuleNames.Add("UnrealEd");
@@ -56,9 +56,14 @@ public class OSVR : ModuleRules
             
             PrivateIncludePaths.AddRange(
                 new string[] {
-                            Path.Combine(EngineDir, @"Source\Runtime\Windows\D3D11RHI\Private"),
-                            Path.Combine(EngineDir, @"Source\Runtime\Windows\D3D11RHI\Private\Windows")
-    				        });
+                    Path.Combine(EngineDir, @"Source\Runtime\Windows\D3D11RHI\Private"),
+                    Path.Combine(EngineDir, @"Source\Runtime\Windows\D3D11RHI\Private\Windows")
+                });
+        }
+
+        if (Target.Platform == UnrealTargetPlatform.Linux)
+        {
+            Definitions.Add("OSVR_UNREAL_OPENGL_ENABLED=1");
         }
     }
 }

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVR.cpp
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVR.cpp
@@ -67,8 +67,10 @@ void FOSVR::LoadOSVRClientKitModule()
     FScopeLock lock(&mModuleMutex);
     if (!bModulesLoaded)
     {
-#if PLATFORM_WINDOWS
         TArray<FString> osvrDlls;
+        TArray<FString> pathsToTry;
+
+#if PLATFORM_WINDOWS        
         osvrDlls.Add(FString("osvrClientKit.dll"));
         osvrDlls.Add(FString("osvrClient.dll"));
         osvrDlls.Add(FString("osvrCommon.dll"));
@@ -78,21 +80,32 @@ void FOSVR::LoadOSVRClientKitModule()
         osvrDlls.Add(FString("glew32.dll"));
         osvrDlls.Add(FString("SDL2.dll"));
 
-#if PLATFORM_64BITS
-        TArray<FString> pathsToTry;
+#if PLATFORM_64BITS        
         pathsToTry.Add(FPaths::GamePluginsDir() / "OSVR/Source/OSVRClientKit/bin/Win64/");
         pathsToTry.Add(FPaths::EngineDir() / "Plugins/Runtime/OSVR/Source/OSVRClientKit/bin/Win64/");
         pathsToTry.Add(FPaths::EngineDir() / "Binaries/ThirdParty/OSVRClientKit/bin/Win64/");
         pathsToTry.Add(FPaths::EngineDir() / "Source/ThirdParty/OSVRClientKit/bin/Win64/");
 
 #else
-        TArray<FString> pathsToTry;
         pathsToTry.Add(FPaths::GamePluginsDir() / "OSVR/Source/OSVRClientKit/bin/Win32/");
         pathsToTry.Add(FPaths::EngineDir() / "Plugins/Runtime/OSVR/Source/OSVRClientKit/bin/Win32/");
         pathsToTry.Add(FPaths::EngineDir() / "Binaries/ThirdParty/OSVRClientKit/bin/Win32/");
         pathsToTry.Add(FPaths::EngineDir() / "Source/ThirdParty/OSVRClientKit/bin/Win32/");
 #endif
 
+#elif PLATFORM_LINUX
+        osvrDlls.Add(FString("libosvrClientKit.so"));
+        osvrDlls.Add(FString("libosvrClient.so"));
+        osvrDlls.Add(FString("libosvrCommon.so"));
+        osvrDlls.Add(FString("libosvrUtil.so"));
+        osvrDlls.Add(FString("libosvrRenderManager.so"));
+        osvrDlls.Add(FString("libjsoncpp.so"));
+        osvrDlls.Add(FString("libGLEW.so"));
+        osvrDlls.Add(FString("libSDL2-2.0.so"));
+
+        pathsToTry.Add(FPaths::GamePluginsDir() / "OSVR/Source/OSVRClientKit/bin/Linux/");
+        pathsToTry.Add(FPaths::EngineDir() / "Plugins/Runtime/OSVR/Source/OSVRClientKit/bin/Linux/");
+#endif
         FString osvrClientKitLibPath;
         for (auto& it : pathsToTry)
         {
@@ -117,10 +130,12 @@ void FOSVR::LoadOSVRClientKitModule()
             if (!libHandle)
             {
                 UE_LOG(OSVRLog, Warning, TEXT("FAILED to load %s"), *path);
+            } else {
+                UE_LOG(OSVRLog, Warning, TEXT("Loaded %s"), *path);
             }
         }
         FPlatformProcess::PopDllDirectory(*osvrClientKitLibPath);
-#endif
+
         bModulesLoaded = true;
     }
 }

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRCustomPresent.h
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRCustomPresent.h
@@ -236,7 +236,8 @@ protected:
 
         OSVR_ReturnCode rc;
         OSVR_RenderInfoCount numRenderInfo;
-        OSVR_Pose3 ret = { 0 };
+        OSVR_Pose3 ret;
+
         rc = osvrRenderManagerGetNumRenderInfoInCollection(renderInfoCollection, &numRenderInfo);
         if (rc != OSVR_RETURN_SUCCESS)
         {

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRCustomPresentOpenGL.h
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRCustomPresentOpenGL.h
@@ -20,7 +20,7 @@
 #include "IOSVR.h"
 #include "OSVRCustomPresent.h"
 #include <osvr/RenderKit/RenderManagerC.h>
-#include <osvr/util/PlatformConfig.h>
+#include <osvr/Util/PlatformConfig.h>
 
 #if OSVR_ANDROID
 // @todo this may not work - if not, what headers is unreal expecting?
@@ -38,7 +38,7 @@
 #include "OpenGLDrvPrivate.h"
 #include "OpenGLResources.h"
 
-typedef struct FUnrealBackBufferContainer
+struct FUnrealBackBufferContainer
 {
     GLint displayFrameBuffer;
     int width;
@@ -105,7 +105,7 @@ private:
         return ConvertBool(((FUnrealOSVRRenderManagerOpenGLToolkit*)data)->handleEvents());
     }
 
-    static OSVR_CBool getDisplayFrameBufferImpl(void* data, size_t display, GLint* displayFrameBufferOut)
+    static OSVR_CBool getDisplayFrameBufferImpl(void* data, size_t display, GLuint* displayFrameBufferOut)
     {
         return ConvertBool(((FUnrealOSVRRenderManagerOpenGLToolkit*)data)->getDisplayFrameBuffer(display, displayFrameBufferOut));
     }
@@ -185,7 +185,7 @@ public:
         return true;
     }
 
-    bool getDisplayFrameBuffer(size_t display, GLint* displayFrameBufferOut)
+    bool getDisplayFrameBuffer(size_t display, GLuint* displayFrameBufferOut)
     {
         (*displayFrameBufferOut) = mBackBufferContainer->displayFrameBuffer;
         return true;
@@ -286,7 +286,7 @@ protected:
             mRenderInfos.Empty();
             for (size_t i = 0; i < numRenderInfo; i++)
             {
-                OSVR_RenderInfoOpenGL renderInfo = { 0 };
+                OSVR_RenderInfoOpenGL renderInfo;
                 rc = osvrRenderManagerGetRenderInfoFromCollectionOpenGL(renderInfoCollection, i, &renderInfo);
                 check(rc == OSVR_RETURN_SUCCESS);
 
@@ -383,8 +383,8 @@ protected:
         check(renderInfoCollection);
 
         OSVR_ReturnCode rc;
-        OSVR_Pose3 ret = { 0 };
-        OSVR_RenderInfoOpenGL renderInfo = { 0 };
+        OSVR_Pose3 ret;
+        OSVR_RenderInfoOpenGL renderInfo;
 
         rc = osvrRenderManagerGetRenderInfoFromCollectionOpenGL(renderInfoCollection, index, &renderInfo);
         if (rc != OSVR_RETURN_SUCCESS)

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVREntryPoint.cpp
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVREntryPoint.cpp
@@ -103,3 +103,8 @@ OSVRInterfaceCollection* OSVREntryPoint::GetInterfaceCollection()
     return InterfaceCollection.Get();
 }
 #endif
+
+// hack to add a dummy implementation of this missing function for Linux until OSVR gets patched
+#if LINUX
+void osvrClientAttemptServerAutoStart() {}
+#endif

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVREntryPoint.h
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVREntryPoint.h
@@ -22,7 +22,7 @@
 
 DECLARE_LOG_CATEGORY_EXTERN(OSVREntryPointLog, Log, All);
 
-OSVR_API class OSVREntryPoint : public FTickableGameObject
+class OSVR_API OSVREntryPoint : public FTickableGameObject
 {
 public:
 

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.cpp
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMD.cpp
@@ -94,7 +94,6 @@ void FOSVRHMD::StartCustomPresent()
 #if PLATFORM_WINDOWS
         else
         {
-
             // currently, FCustomPresent creates its own client context, so no need to
             // synchronize with the one from FOSVREntryPoint.
             mCustomPresent = new FDirect3D11CustomPresent(nullptr/*mOSVREntryPoint->GetClientContext()*/);
@@ -215,6 +214,13 @@ void FOSVRHMD::UpdateHeadPose(bool renderThread, FQuat& lastHmdOrientation, FVec
 {
     //OSVR_ReturnCode returnCode;
     FScopeLock lock(mOSVREntryPoint->GetClientContextMutex());
+
+    if(!mCustomPresent)
+    {
+        UE_LOG(OSVRHMDLog, Warning, TEXT("Skipping head pose update because mCustomPresent is not initialized yet!"));
+        return;
+    }
+    
     OSVR_Pose3 pose = mCustomPresent->GetHeadPoseFromCachedRenderInfoCollection(renderThread, true);
     
     // RenderManager gives us the eye-from-space pose, and we need the inverse of that

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRPrivatePCH.h
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRPrivatePCH.h
@@ -37,7 +37,10 @@
 // in the background and no way to switch apps).
 #define OSVR_UNREAL_DEBUG_FORCED_WINDOWMODE 0
 
+// If not explicitly enabled (e.g. for Linux), keep OpenGL support off 
+#ifndef OSVR_UNREAL_OPENGL_ENABLED
 #define OSVR_UNREAL_OPENGL_ENABLED 0
+#endif
 
 //// Set to 1 to enable OpenGL RenderManager support on Windows, which is currently
 //// in beta form. There are known issues:

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRRender.cpp
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRRender.cpp
@@ -147,6 +147,8 @@ void FOSVRHMD::CalculateRenderTargetSize(const FViewport& Viewport, uint32& InOu
         if (!mCustomPresent->IsInitialized() && IsInRenderingThread() && !mCustomPresent->Initialize())
         {
             mCustomPresent = nullptr;
+            UE_LOG(OSVRHMDLog, Error, TEXT("Failed to initialise CustomPresent!"));
+            return;
         }
 
         // this only happens once, the first time this is called. I don't know why.

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Public/IOSVR.h
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Public/IOSVR.h
@@ -29,7 +29,7 @@ class FOSVRHMD;
 * The public interface to this module.  In most cases, this interface is only public to sibling modules
 * within this plugin.
 */
-OSVR_API class IOSVR : public IHeadMountedDisplayModule
+class OSVR_API IOSVR : public IHeadMountedDisplayModule
 {
 public:
     /** Returns the key into the HMDPluginPriority section of the config file for this module */

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVRClientKit/OSVRClientKit.Build.cs
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVRClientKit/OSVRClientKit.Build.cs
@@ -64,5 +64,40 @@ public class OSVRClientKit : ModuleRules
             //System.Console.WriteLine("xmlPath: {0}", xmlPath);
             AdditionalPropertiesForReceipt.Add(new ReceiptProperty("AndroidPlugin", xmlPath));
         }
+        else if(Target.Platform == UnrealTargetPlatform.Linux)
+        {
+            string PlatformAbbrev = "Linux";
+
+            PublicLibraryPaths.Add(String.Format("{0}/bin/{1}", ModuleDirectory, PlatformAbbrev));
+            PublicAdditionalLibraries.Add("osvrClientKit");
+            PublicAdditionalLibraries.Add("osvrRenderManager");
+
+            var osvrDlls = new string[] {
+                "libosvrClientKit.so",
+                "libosvrClient.so",
+                "libosvrCommon.so",
+                "libosvrUtil.so",
+                "libosvrRenderManager.so",
+                "libjsoncpp.so",
+                "libGLEW.so",
+                "libSDL2-2.0.so"
+              };
+
+            PublicDelayLoadDLLs.AddRange(osvrDlls);
+
+            string baseBinaryDirectory = ModuleDirectory + "/bin";
+            if (!System.IO.Directory.Exists(baseBinaryDirectory))
+            {
+                baseBinaryDirectory = "$(EngineDir)/Binaries/ThirdParty/OSVRClientKit/bin";
+            }
+
+            string DllFormat = "{0}/{1}/{2}";
+            foreach (var dll in osvrDlls)
+            {
+                var src = String.Format(DllFormat, baseBinaryDirectory, PlatformAbbrev, dll);
+                RuntimeDependencies.Add(new RuntimeDependency(src));
+            }
+            
+        }
     }
 }

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVRInput/OSVRInput.Build.cs
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVRInput/OSVRInput.Build.cs
@@ -10,36 +10,33 @@ public class OSVRInput : ModuleRules
         var openglPath = Path.Combine(EngineDir, @"Source\ThirdParty\OpenGL");
         PrivateIncludePaths.AddRange(
             new string[] {
-				"OSVR/Private",
+                "OSVR/Private",
                 openglDrvPrivatePath,
                 openglPath,
-				// ... add other private include paths required here ...
+                // ... add other private include paths required here ...
                 "/media/u/build/OSVR/install/include/"
-			}
-            );
-
-
+            });
 
         PrivateDependencyModuleNames.AddRange(
             new string[]
-			{
-				"OSVRClientKit",
-                "OSVR",
-                "Core",
-				"CoreUObject",      // Provides Actors and Structs
-				"Engine",           // Used by Actor
-				"Slate",            // Used by InputDevice to fire bespoke FKey events
-				"InputCore",        // Provides LOCTEXT and other Input features
-				"InputDevice",      // Provides IInputInterface
-				"RHI",
-				"RenderCore",
-				"Renderer",
-				"ShaderCore",
-				"HeadMountedDisplay",
-				"Json",
-                "OpenGLDrv"
-				// ... add private dependencies that you statically link with here ...
-			}
+                {
+                    "OSVRClientKit",
+                    "OSVR",
+                    "Core",
+                    "CoreUObject",      // Provides Actors and Structs
+                    "Engine",           // Used by Actor
+                    "Slate",            // Used by InputDevice to fire bespoke FKey events
+                    "InputCore",        // Provides LOCTEXT and other Input features
+                    "InputDevice",      // Provides IInputInterface
+                    "RHI",
+                    "RenderCore",
+                    "Renderer",
+                    "ShaderCore",
+                    "HeadMountedDisplay",
+                    "Json",
+                    "OpenGLDrv"
+                    // ... add private dependencies that you statically link with here ...
+                }
             );
 
         AddEngineThirdPartyPrivateStaticDependencies(Target, "OpenGL");
@@ -57,9 +54,9 @@ public class OSVRInput : ModuleRules
             // Required for some private headers needed for the rendering support.
             PrivateIncludePaths.AddRange(
                 new string[] {
-                            Path.Combine(EngineDir, @"Source\Runtime\Windows\D3D11RHI\Private"),
-                            Path.Combine(EngineDir, @"Source\Runtime\Windows\D3D11RHI\Private\Windows")
-                            });
+                    Path.Combine(EngineDir, @"Source\Runtime\Windows\D3D11RHI\Private"),
+                    Path.Combine(EngineDir, @"Source\Runtime\Windows\D3D11RHI\Private\Windows")
+                });
         }
     }
 }

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVRInput/OSVRInput.Build.cs
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVRInput/OSVRInput.Build.cs
@@ -12,8 +12,9 @@ public class OSVRInput : ModuleRules
             new string[] {
 				"OSVR/Private",
                 openglDrvPrivatePath,
-                openglPath
+                openglPath,
 				// ... add other private include paths required here ...
+                "/media/u/build/OSVR/install/include/"
 			}
             );
 

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVRInput/Private/OSVRInputDevice.cpp
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVRInput/Private/OSVRInputDevice.cpp
@@ -51,12 +51,12 @@ class OSVRButton
 public:
     OSVRButton() {}
     OSVRButton(OSVRButtonType _type, FName _key, const FString& _ifacePath) :
-        type(_type), key(_key), ifacePath(_ifacePath)
+        key(_key), ifacePath(_ifacePath), type(_type)
     {
     }
 
     OSVRButton(OSVRButtonType _type, OSVRThresholdType _thresholdType, float _threshold, FName _key, const FString& _ifacePath) :
-        type(_type), thresholdType(_thresholdType), threshold(_threshold), key(_key), ifacePath(_ifacePath)
+        threshold(_threshold), key(_key), ifacePath(_ifacePath), type(_type), thresholdType(_thresholdType)
     {
     }
 


### PR DESCRIPTION
Hello, 

Here is an initial attempt at a native (not cross-compiled) Linux support for UE4. It does work to the point that the plugin actually loads and lets me move a cube on the screen using my Razer Hydra in the editor. I **have not** tested the HMD/RenderManager stuff - it compiles and loads, but I don't have a working HMD set up in Linux at the moment and I have never used it before, so I would prefer someone more knowledgeable about it to test that. 

There are a few things that need modifying:
- In the build files, the names of the Linux libraries to link against and to preload may have to be adapted to  whatever UE4 ships with. I am referring mainly to SDL and GLEW versions, however OSVR depends also on Boost and a few other things. The plugin may have to include all of these in some 3rdparty folder, because different Linux distros have their own (potentially incompatible) versions. Maybe rely on the SteamOS SDK? This probably needs to be addressed together with Unreal developers, I don't know what their policy for individual platforms is regarding this. I have built the code on my Mageia Linux 5, but I presume the official build is more likely to be something Ubuntu LTS-like.
- The same story with the path to the OSVR header files - this **must** be changed in OSVR.Build.cs and OSVRInput.Build.cs, right now there is a hardwired path to OSVR on my system - i.e. it won't work for anyone else! Unfortunately, I don't know what to change this to, no idea where UE ships OSVR's headers.
- There is a temporary kludge in OSVR/Private/OSVREntryPoint.cpp - OSVR doesn't implement void osvrClientAttemptServerAutoStart() for Linux for some reason, so I had to add a dummy implementation to that file to make it link. Once this function is available for Linux this kludge needs to be removed. 
