### PR TITLE
Removed assert that HMD has only one display input. We don't depend o…

### DIFF
--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMDDescription.cpp
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRHMDDescription.cpp
@@ -54,15 +54,7 @@ bool OSVRHMDDescription::OSVRViewerFitsUnrealModel(OSVR_DisplayConfig displayCon
     }
 
     OSVR_ReturnCode returnCode;
-    
-    // must be only one display input
-    OSVR_DisplayInputCount numDisplayInputs;
-    returnCode = osvrClientGetNumDisplayInputs(displayConfig, &numDisplayInputs);
-    if (returnCode == OSVR_RETURN_FAILURE || numDisplayInputs != 1)
-    {
-        UE_LOG(OSVRHMDDescriptionLog, Warning, TEXT("osvrClientGetNumDisplayInputs call failed or number of display inputs not equal to 1"));
-        return false;
-    }
+
 
     // must be only one viewer
     OSVR_ViewerCount numViewers;


### PR DESCRIPTION
…n that being true anywhere, as the current code will work for both one or two input HMDs.

Fixes: https://github.com/OSVR/OSVR-Unreal/issues/128