### PR TITLE
Added nullptr checks for mRenderManager in OSVRCustomPresent, OSVRCustomPresentD3D11, and OSVRCustomPresentOpenGL.

### DIFF
--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRCustomPresentD3D11.h
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRCustomPresentD3D11.h
@@ -293,6 +293,8 @@ protected:
 
             bInitialized = true;
         }
+        // mRenderManager must be non-nullptr if we're returning true.
+        check(mRenderManager);
         return true;
     }
 
@@ -325,6 +327,13 @@ protected:
     {
         check(IsInitialized());
         check(IsInRenderingThread());
+
+        if (!mRenderManager)
+        {
+            UE_LOG(FOSVRCustomPresentLog, Warning,
+                TEXT("FDirect3D11CustomPresent::FinishRendering() - mRenderManager is null. Should be non-null at this point."));
+            return;
+        }
 
         if (!mCachedRenderThreadRenderInfoCollection)
         {
@@ -388,7 +397,8 @@ protected:
         HRESULT hr;
         check(IsInRenderingThread());
         check(IsInitialized());
-        
+        check(mRenderManager);
+
         if (bRenderBuffersNeedToUpdate)
         {
             if (!bDisplayOpen)

--- a/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRCustomPresentOpenGL.h
+++ b/OSVRUnreal/Plugins/OSVR/Source/OSVR/Private/OSVRCustomPresentOpenGL.h
@@ -349,6 +349,9 @@ protected:
             // LazyOpenDisplay needs to be called on the rendering thread to open the display
             bInitialized = true;
         }
+
+        // mRenderManager must be non-nullptr if we're returning true.
+        check(mRenderManager);
         return true;
     }
 
@@ -408,6 +411,13 @@ protected:
     {
         check(IsInitialized());
 
+        if (!mRenderManager)
+        {
+            UE_LOG(FOSVRCustomPresentLog, Warning,
+                TEXT("FOpenGLCustomPresent::FinishRendering() - mRenderManager is null. Should be non-null at this point."));
+            return;
+        }
+
         // @todo: this needs to be more robust.
         // Can we find this by inspection of the view somehow?
         // After the first call, the framebuffer ends up set to
@@ -447,6 +457,8 @@ protected:
         OSVR_ReturnCode rc;
 
         check(IsInitialized());
+        check(mRenderManager);
+
         if (bRenderBuffersNeedToUpdate)
         {
             //check(RenderTargetTexture);


### PR DESCRIPTION
See: https://github.com/OSVR/OSVR-Unreal/issues/140